### PR TITLE
[BE feat] Open API 적금 조회 정보 DB 자동 저장 기능 구현

### DIFF
--- a/server/src/main/java/com/team1472/moas/MoasApplication.java
+++ b/server/src/main/java/com/team1472/moas/MoasApplication.java
@@ -3,9 +3,11 @@ package com.team1472.moas;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableScheduling
 public class MoasApplication {
 
     public static void main(String[] args) {

--- a/server/src/main/java/com/team1472/moas/installment_savings/controller/OpenApiController.java
+++ b/server/src/main/java/com/team1472/moas/installment_savings/controller/OpenApiController.java
@@ -1,0 +1,65 @@
+package com.team1472.moas.installment_savings.controller;
+
+import com.team1472.moas.installment_savings.service.OpenApiService;
+import com.team1472.moas.util.secret.OpenApiAuthKey;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+
+@RestController
+@RequestMapping("/open-api")
+@RequiredArgsConstructor
+public class OpenApiController {
+    private final OpenApiService openApiService;
+    private final OpenApiAuthKey authKey;
+
+    @GetMapping("/savings")
+    public ResponseEntity saveInstallmentSavingsInfo() throws IOException {
+        callOpenApi();
+
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+    private void callOpenApi() throws IOException {
+        int totalPageNum = 1; // 전체 페이지 수
+        int curPageNum = 1; // 현재 페이지 수
+
+        do {
+            StringBuilder urlBuilder = new StringBuilder("http://finlife.fss.or.kr/finlifeapi/savingProductsSearch.json");
+            urlBuilder.append("?auth=" + authKey.getKey());
+            urlBuilder.append("&topFinGrpNo=020000"); //권역번호 : 020000(은행)
+            urlBuilder.append("&pageNo=" + curPageNum);
+
+            URL url = new URL(urlBuilder.toString());
+
+            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+            conn.setRequestMethod("GET");
+            conn.setRequestProperty("Content-type", "application/json");
+
+            BufferedReader rd = new BufferedReader(new InputStreamReader(conn.getInputStream()));
+
+            StringBuilder sb = new StringBuilder();
+            String line;
+            while ((line = rd.readLine()) != null) {
+                sb.append(line);
+            }
+            String data = sb.toString();
+            rd.close();
+            conn.disconnect();
+
+            totalPageNum = openApiService.getInstallmentSavingsInfo(data);
+            curPageNum++;
+
+        } while (curPageNum <= totalPageNum);
+    }
+}

--- a/server/src/main/java/com/team1472/moas/installment_savings/controller/OpenApiController.java
+++ b/server/src/main/java/com/team1472/moas/installment_savings/controller/OpenApiController.java
@@ -3,8 +3,12 @@ package com.team1472.moas.installment_savings.controller;
 import com.team1472.moas.installment_savings.service.OpenApiService;
 import com.team1472.moas.util.secret.OpenApiAuthKey;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -15,7 +19,7 @@ import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
 
-
+@Slf4j
 @RestController
 @RequestMapping("/open-api")
 @RequiredArgsConstructor
@@ -23,6 +27,11 @@ public class OpenApiController {
     private final OpenApiService openApiService;
     private final OpenApiAuthKey authKey;
 
+    /**
+     * Open API를 통한 적금 정보 조회 후 DB 저장
+     * 서버 실행 시 자동 수행
+     */
+    @EventListener(ApplicationReadyEvent.class)
     @GetMapping("/savings")
     public ResponseEntity saveInstallmentSavingsInfo() throws IOException {
         callOpenApi();
@@ -30,6 +39,18 @@ public class OpenApiController {
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
+    /**
+     * Open API를 통한 적금 정보 자동 업데이트
+     * 매일 새벽 4시 자동 업데이트
+     */
+    @Scheduled(cron = "0 0 4 * * ?") // 매일 새벽 4시 자동 업데이트
+    public void deleteAndSaveInstallmentSavingsInfo() throws IOException {
+        log.info("적금 정보 자동 업데이트 시작");
+        openApiService.deleteAllData();
+        callOpenApi();
+    }
+
+    // 금융감독원 적금 조회 Open API 호출
     private void callOpenApi() throws IOException {
         int totalPageNum = 1; // 전체 페이지 수
         int curPageNum = 1; // 현재 페이지 수

--- a/server/src/main/java/com/team1472/moas/installment_savings/entity/InstallmentSavings.java
+++ b/server/src/main/java/com/team1472/moas/installment_savings/entity/InstallmentSavings.java
@@ -1,7 +1,7 @@
 package com.team1472.moas.installment_savings.entity;
 
 import lombok.AllArgsConstructor;
-import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
@@ -9,7 +9,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Entity
-@Builder
+@Getter
 @NoArgsConstructor
 @AllArgsConstructor
 public class InstallmentSavings {
@@ -17,31 +17,31 @@ public class InstallmentSavings {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private long fin_co_no; //금융회사 코드
+    private String finCoNo; //금융회사 코드
 
-    private String kor_co_nm; //금융회사 명
+    private String korCoNm; //금융회사 명
 
-    private long fin_prdt_cd; //금융 상품 코드
+    private String finPrdtCd; //금융 상품 코드
 
-    private String fin_prdt_nm; //금융상품명
+    private String finPrdtNm; //금융상품명
 
-    private String join_way; //가입 방법
-
-    @Column(columnDefinition = "TEXT")
-    private String mtrt_int; //만기 후 이자율
+    private String joinWay; //가입 방법
 
     @Column(columnDefinition = "TEXT")
-    private String spcl_cnd; //우대 조건
-
-    private int join_deny; //가입제한
+    private String mtrtInt; //만기 후 이자율
 
     @Column(columnDefinition = "TEXT")
-    private String join_member; //가입 대상
+    private String spclCnd; //우대 조건
+
+    private String joinDeny; //가입제한
 
     @Column(columnDefinition = "TEXT")
-    private String etc_note; //기타 유의사항
+    private String joinMember; //가입 대상
 
-    private int max_limit; //최고 한도
+    @Column(columnDefinition = "TEXT")
+    private String etcNote; //기타 유의사항
+
+    private int maxLimit; //최고 한도
 
     @OneToMany(mappedBy = "installmentSavings", cascade = {CascadeType.PERSIST, CascadeType.REMOVE})
     private List<InterestRate> interestRates = new ArrayList<>();

--- a/server/src/main/java/com/team1472/moas/installment_savings/entity/InterestRate.java
+++ b/server/src/main/java/com/team1472/moas/installment_savings/entity/InterestRate.java
@@ -37,4 +37,8 @@ public class InterestRate {
     @JoinColumn(name = "INSTALLMENTSAVINGS_ID")
     private InstallmentSavings installmentSavings;
 
+    public void addInstallmentSavings(InstallmentSavings installmentSavings) {
+        this.installmentSavings = installmentSavings;
+    }
+
 }

--- a/server/src/main/java/com/team1472/moas/installment_savings/entity/InterestRate.java
+++ b/server/src/main/java/com/team1472/moas/installment_savings/entity/InterestRate.java
@@ -1,13 +1,13 @@
 package com.team1472.moas.installment_savings.entity;
 
 import lombok.AllArgsConstructor;
-import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 
 @Entity
-@Builder
+@Getter
 @NoArgsConstructor
 @AllArgsConstructor
 public class InterestRate {
@@ -15,23 +15,23 @@ public class InterestRate {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private String fin_co_no; //금융 회사 코드
+    private String finCoNo; //금융 회사 코드
 
-    private String fin_prdt_cd; //금융 상품 코드 => FK로 사용
+    private String finPrdtCd; //금융 상품 코드 => FK로 사용
 
-    private String intr_rate_type; // 저축 금리 유형
+    private String intrRateType; // 저축 금리 유형
 
-    private String intr_rate_type_nm; // 저축 금리 유형명
+    private String intrRateTypeNm; // 저축 금리 유형명
 
-    private String rsrv_type; //적립 유형
+    private String rsrvType; //적립 유형
 
-    private String rsrv_type_nm; //적립 유형명
+    private String rsrvTypeNm; //적립 유형명
 
-    private String save_trm; // 저축 기간(단위: 개월)
+    private String saveTrm; // 저축 기간(단위: 개월)
 
-    private double intr_rate; //저축 금리(소수점 2자리)
+    private double intrRate; //저축 금리(소수점 2자리)
 
-    private double intr_rate2; //최고 우대 금리(소수점 2자리)
+    private double intrRate2; //최고 우대 금리(소수점 2자리)
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "INSTALLMENTSAVINGS_ID")

--- a/server/src/main/java/com/team1472/moas/installment_savings/repository/InstallmentSavingsRepository.java
+++ b/server/src/main/java/com/team1472/moas/installment_savings/repository/InstallmentSavingsRepository.java
@@ -1,0 +1,10 @@
+package com.team1472.moas.installment_savings.repository;
+
+import com.team1472.moas.installment_savings.entity.InstallmentSavings;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface InstallmentSavingsRepository extends JpaRepository<InstallmentSavings, Long> {
+    Optional<InstallmentSavings> findByfinPrdtCd(String productCode);
+}

--- a/server/src/main/java/com/team1472/moas/installment_savings/repository/InterestRateRepository.java
+++ b/server/src/main/java/com/team1472/moas/installment_savings/repository/InterestRateRepository.java
@@ -1,0 +1,7 @@
+package com.team1472.moas.installment_savings.repository;
+
+import com.team1472.moas.installment_savings.entity.InterestRate;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface InterestRateRepository extends JpaRepository<InterestRate, Long> {
+}

--- a/server/src/main/java/com/team1472/moas/installment_savings/service/OpenApiService.java
+++ b/server/src/main/java/com/team1472/moas/installment_savings/service/OpenApiService.java
@@ -1,0 +1,92 @@
+package com.team1472.moas.installment_savings.service;
+
+import com.google.gson.*;
+import com.team1472.moas.installment_savings.entity.InstallmentSavings;
+import com.team1472.moas.installment_savings.entity.InterestRate;
+import com.team1472.moas.installment_savings.repository.InstallmentSavingsRepository;
+import com.team1472.moas.installment_savings.repository.InterestRateRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class OpenApiService {
+    private final InstallmentSavingsRepository installmentSavingsRepository;
+    private final InterestRateRepository interestRateRepository;
+
+    //금융감독원 적금 정보 파싱 후 DB 저장
+    public int getInstallmentSavingsInfo(String jsonData) {
+        Gson gson = new GsonBuilder()
+                .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
+                .create();
+
+        JsonElement element = JsonParser.parseString(jsonData);
+        JsonObject object = element.getAsJsonObject();
+
+        JsonObject result = object.getAsJsonObject("result");
+
+        if (!checkSuccessfulApiCall(result)) { //에러 발생 여부 확인
+            return 0;
+        }
+
+        int totalPageNum = result.get("max_page_no").getAsInt();
+
+        JsonArray baseList = result.get("baseList").getAsJsonArray(); //적금 기본 정보 리스트
+        List<InstallmentSavings> savingsList = parseInstallmentSavingsInfo(baseList, gson);
+        installmentSavingsRepository.saveAll(savingsList);
+
+        JsonArray optionList = result.get("optionList").getAsJsonArray(); //적금 이자율에 대한 정보 리스트
+        List<InterestRate> interestRateList = parseInterestRateInfo(optionList, gson);
+        interestRateRepository.saveAll(interestRateList);
+
+
+        return totalPageNum;
+    }
+
+    //에러 발생 여부 확인
+    private boolean checkSuccessfulApiCall(JsonObject response) {
+        String errorCode = response.get("err_cd").getAsString();
+
+        if (!errorCode.equals("000")) {
+            log.error("적금 조회 Open API 호출 실패 [응답 코드: " + errorCode + " 응답 메시지: " + response.get("err_msg") + "]");
+            return false;
+        }
+
+        return true;
+    }
+
+    //적금 상품에 대한 기본 정보 파싱
+    private List<InstallmentSavings> parseInstallmentSavingsInfo(JsonArray baseList, Gson gson) {
+        InstallmentSavings[] installmentSavings = gson.fromJson(baseList, InstallmentSavings[].class);
+
+        return Arrays.asList(installmentSavings);
+    }
+
+    //적금 상품의 이자율 정보 파싱
+    private List<InterestRate> parseInterestRateInfo(JsonArray optionList, Gson gson) {
+        List<InterestRate> interestRateList = new ArrayList<>();
+
+        for (int i = 0; i < optionList.size(); i++) {
+            JsonObject data = (JsonObject) optionList.get(i);
+
+            InterestRate interestRate = gson.fromJson(data, InterestRate.class);
+            Optional<InstallmentSavings> optSavings = installmentSavingsRepository.findByfinPrdtCd(interestRate.getFinPrdtCd());
+
+            optSavings.ifPresent(savings -> {
+                interestRate.addInstallmentSavings(savings);
+                interestRateList.add(interestRate);
+            });
+        }
+
+        return interestRateList;
+    }
+}

--- a/server/src/main/java/com/team1472/moas/installment_savings/service/OpenApiService.java
+++ b/server/src/main/java/com/team1472/moas/installment_savings/service/OpenApiService.java
@@ -89,4 +89,10 @@ public class OpenApiService {
 
         return interestRateList;
     }
+
+    // 적금, 이자 정보 데이터 전부 삭제
+    public void deleteAllData() {
+        interestRateRepository.deleteAllInBatch();
+        installmentSavingsRepository.deleteAllInBatch();
+    }
 }

--- a/server/src/main/java/com/team1472/moas/util/secret/OpenApiAuthKey.java
+++ b/server/src/main/java/com/team1472/moas/util/secret/OpenApiAuthKey.java
@@ -1,0 +1,14 @@
+package com.team1472.moas.util.secret;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties(prefix = "open-api")
+@Getter
+@Setter
+public class OpenApiAuthKey {
+    private String key; //적금 조회 open api 인증 키
+}


### PR DESCRIPTION
# Open API 적금 조회 정보 DB 자동 저장 기능 구현
---
## 주요 구현 내용
- 금융감독원에서 제공하는 적금 조회 Open API 연결
- 조회한 적금 상품 정보 DB 저장
- 애플리케이션 서버를 맨 처음 실행할 때 자동으로 적금 상품 정보 DB 저장
- 매일 새벽 4시 적금 상품 정보 자동 업데이트

### 상세 설명
Open api에서 넘어오는 정보가 적금 기본 정보 하위에 기간별 금리 리스트가 있는 구조가 아니라
기본적인 적금 상품에 대한 리스트(baseList)와 해당 적금 상품의 기간별 금리 리스트(optionList)가 같은 계층으로 따로 넘어오는 상황입니다.
금리 리스트와 적금 상품을 매칭하기 위해서는 'fin_prdt_cd'라는 금융 상품 코드를 이용해야 합니다.
해당 필드를 이용하여 InterestRate(적금 상품의 금리) 엔티티에서 installmentSavings 필드에 해당하는 객체를 추가하고 있습니다. 


## 추후 고려 사항
- MySql의 auto increment 전략으로 인한 bulk insert 불가로 인한 성능 이슈
- interestRage의 'fin_prdt_cd'와 같은 installmentSavings의 'fin_prdt_cd'를 찾기 위한 반복적인 조회 시도로 인한 성능 이슈

---
Open API : http://finlife.fss.or.kr/PageLink.do?link=openapi/detail03&menuId=2000127
Issue closes #4 