### PR TITLE
[BE Feat] 목표 도메인 CRUD 기능 구현

### DIFF
--- a/server/.gitignore
+++ b/server/.gitignore
@@ -4,6 +4,7 @@ build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/
+.yml
 
 ### STS ###
 .apt_generated

--- a/server/src/main/java/com/team1472/moas/exception/ExceptionCode.java
+++ b/server/src/main/java/com/team1472/moas/exception/ExceptionCode.java
@@ -4,7 +4,7 @@ import lombok.Getter;
 
 @Getter
 public enum ExceptionCode {
-    ;
+    GOAL_NOT_FOUND(404,"해당 목표를 찾을 수 없습니다.");
 
     private int status;
     private String message;

--- a/server/src/main/java/com/team1472/moas/goal/controller/GoalController.java
+++ b/server/src/main/java/com/team1472/moas/goal/controller/GoalController.java
@@ -6,6 +6,7 @@ import com.team1472.moas.goal.entity.Goal;
 import com.team1472.moas.goal.mapper.GoalMapper;
 import com.team1472.moas.goal.repository.GoalRepository;
 import com.team1472.moas.goal.service.GoalService;
+import com.team1472.moas.member.entity.Member;
 import com.team1472.moas.member.service.MemberService;
 import com.team1472.moas.response.MultiResponse;
 import com.team1472.moas.response.SingleResponse;
@@ -42,11 +43,11 @@ public class GoalController {
     }
 
     //목표 수정
-    @PatchMapping("/{member-id}")
+    @PatchMapping("/{member-id}/{goal-id}")
     public ResponseEntity patchGoal(@PathVariable("member-id") @Positive long memberId,
+                                    @PathVariable("goal-id") @Positive long id,
                                     @Valid @RequestBody GoalPatchRes goalPatchRes) {
-        goalPatchRes.setMemberId(memberId);
-        Goal goal = goalService.updateGoal(mapper.goalPatchDtoToGoal(goalPatchRes));
+        Goal goal = goalService.updateGoal(mapper.goalPatchDtoToGoal(goalPatchRes),id);
 
         return new ResponseEntity<>(
                 new SingleResponse<>(mapper.goalToGoalResponseDto(goal)),

--- a/server/src/main/java/com/team1472/moas/goal/controller/GoalController.java
+++ b/server/src/main/java/com/team1472/moas/goal/controller/GoalController.java
@@ -1,0 +1,80 @@
+package com.team1472.moas.goal.controller;
+
+import com.team1472.moas.goal.dto.GoalPatchRes;
+import com.team1472.moas.goal.dto.GoalPostRes;
+import com.team1472.moas.goal.entity.Goal;
+import com.team1472.moas.goal.mapper.GoalMapper;
+import com.team1472.moas.goal.repository.GoalRepository;
+import com.team1472.moas.goal.service.GoalService;
+import com.team1472.moas.member.service.MemberService;
+import com.team1472.moas.response.MultiResponse;
+import com.team1472.moas.response.SingleResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.coyote.Response;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+import javax.validation.constraints.Positive;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/goals")
+@Validated
+@Slf4j
+@RequiredArgsConstructor
+public class GoalController {
+    private final GoalService goalService;
+    private final GoalMapper mapper;
+
+    //목표 등록
+    @PostMapping("/{member-id}")
+    public ResponseEntity postGoal(@PathVariable("member-id") @Positive long memberId,
+                                   @Valid @RequestBody GoalPostRes goalPostRes) {
+        Goal createdGoal = goalService.createGoal(mapper.goalPostDtoToGoal(goalPostRes), memberId);
+
+        return new ResponseEntity<>(
+                new SingleResponse<>(mapper.goalToGoalResponseDto(createdGoal)),
+                HttpStatus.CREATED);
+    }
+
+    //목표 수정
+    @PatchMapping("/{member-id}")
+    public ResponseEntity patchGoal(@PathVariable("member-id") @Positive long memberId,
+                                    @Valid @RequestBody GoalPatchRes goalPatchRes) {
+        goalPatchRes.setMemberId(memberId);
+        Goal goal = goalService.updateGoal(mapper.goalPatchDtoToGoal(goalPatchRes));
+
+        return new ResponseEntity<>(
+                new SingleResponse<>(mapper.goalToGoalResponseDto(goal)),
+                HttpStatus.OK);
+    }
+
+    //목표 상세 조회
+    @GetMapping("/{member-id}/{id}")
+    public ResponseEntity getGoal(@PathVariable("id") @Positive long id) {
+        Goal goal = goalService.findGoal(id);
+        return new ResponseEntity<>(
+                new SingleResponse<>(mapper.goalToGoalResponseDto(goal)),
+                HttpStatus.OK);
+    }
+
+    //목표 전체 조회(페이지네이션 적용 X)
+    @GetMapping("/{member-id}")
+    public ResponseEntity getQuestions() {
+        List<Goal> goals = goalService.findGoals();
+        return new ResponseEntity<>(
+                new MultiResponse<>(mapper.goalsToGoalResponseDtos(goals)),
+                HttpStatus.OK);
+    }
+
+    //목표 삭제
+    @DeleteMapping("/{member-id}/{id}")
+    public ResponseEntity deleteGoal(@PathVariable("id") @Positive long id) {
+        goalService.deleteGoal(id);
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
+}

--- a/server/src/main/java/com/team1472/moas/goal/dto/GoalPatchRes.java
+++ b/server/src/main/java/com/team1472/moas/goal/dto/GoalPatchRes.java
@@ -1,0 +1,30 @@
+package com.team1472.moas.goal.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class GoalPatchRes {
+    @NotNull(message = "반드시 값이 존재해야 합니다.")
+    private Long id; //목표ID
+
+    @NotNull(message = "반드시 값이 존재해야 합니다.")
+    private long memberId; //회원ID
+
+    @NotBlank(message = "목표명은 공백이 아니어야 합니다.")
+    private String goalName; //목표명
+
+    @NotNull(message = "반드시 목표 금액이 존재해야 합니다.")
+    private long price; //목표 금액
+
+    @NotNull(message = "반드시 월 납입금액이 존재해야 합니다.")
+    private long monthlyPayment; //월 납입금
+
+    private long currentPayment; //현재 납입액 --> 제거 여부?
+}

--- a/server/src/main/java/com/team1472/moas/goal/dto/GoalPatchRes.java
+++ b/server/src/main/java/com/team1472/moas/goal/dto/GoalPatchRes.java
@@ -11,20 +11,10 @@ import javax.validation.constraints.NotNull;
 @Setter
 @AllArgsConstructor
 public class GoalPatchRes {
-    @NotNull(message = "반드시 값이 존재해야 합니다.")
-    private Long id; //목표ID
-
-    @NotNull(message = "반드시 값이 존재해야 합니다.")
-    private long memberId; //회원ID
-
     @NotBlank(message = "목표명은 공백이 아니어야 합니다.")
     private String goalName; //목표명
-
     @NotNull(message = "반드시 목표 금액이 존재해야 합니다.")
     private long price; //목표 금액
-
     @NotNull(message = "반드시 월 납입금액이 존재해야 합니다.")
     private long monthlyPayment; //월 납입금
-
-    private long currentPayment; //현재 납입액 --> 제거 여부?
 }

--- a/server/src/main/java/com/team1472/moas/goal/dto/GoalPostRes.java
+++ b/server/src/main/java/com/team1472/moas/goal/dto/GoalPostRes.java
@@ -1,0 +1,22 @@
+package com.team1472.moas.goal.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
+@Getter
+@AllArgsConstructor
+public class GoalPostRes {
+    @NotNull(message = "반드시 값이 존재해야 합니다.")
+    private Long id; //목표ID
+    @NotNull(message = "반드시 값이 존재해야 합니다.")
+    private long memberId; //회원ID
+    @NotBlank(message = "목표명은 공백이 아니어야 합니다.")
+    private String goalName; //목표명
+    @NotNull(message = "반드시 목표 금액이 존재해야 합니다.")
+    private long price; //목표 금액
+    @NotNull(message = "반드시 월 납입 금액이 존재해야 합니다.")
+    private long monthlyPayment; //월 납입금
+}

--- a/server/src/main/java/com/team1472/moas/goal/dto/GoalPostRes.java
+++ b/server/src/main/java/com/team1472/moas/goal/dto/GoalPostRes.java
@@ -9,10 +9,6 @@ import javax.validation.constraints.NotNull;
 @Getter
 @AllArgsConstructor
 public class GoalPostRes {
-    @NotNull(message = "반드시 값이 존재해야 합니다.")
-    private Long id; //목표ID
-    @NotNull(message = "반드시 값이 존재해야 합니다.")
-    private long memberId; //회원ID
     @NotBlank(message = "목표명은 공백이 아니어야 합니다.")
     private String goalName; //목표명
     @NotNull(message = "반드시 목표 금액이 존재해야 합니다.")

--- a/server/src/main/java/com/team1472/moas/goal/dto/GoalRes.java
+++ b/server/src/main/java/com/team1472/moas/goal/dto/GoalRes.java
@@ -1,0 +1,22 @@
+package com.team1472.moas.goal.dto;
+
+import com.team1472.moas.goal.entity.Goal;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class GoalRes {
+    private long id; //목표ID
+    private long memberId; //회원ID
+    private String goalName; //목표명
+    private long price; //목표 금액
+    private long principle; //원금
+    private long monthlyPayment; //월 납입금
+    private LocalDateTime paymentStart; //납입 시작일
+    private int period; //기간
+    private String url; //이미지 url
+    private Goal.GoalStatus status; //목표 진행상태
+}

--- a/server/src/main/java/com/team1472/moas/goal/dto/GoalRes.java
+++ b/server/src/main/java/com/team1472/moas/goal/dto/GoalRes.java
@@ -11,12 +11,11 @@ import java.time.LocalDateTime;
 public class GoalRes {
     private long id; //목표ID
     private long memberId; //회원ID
+    private String url; //이미지 url
     private String goalName; //목표명
     private long price; //목표 금액
-    private long principle; //원금
     private long monthlyPayment; //월 납입금
     private LocalDateTime paymentStart; //납입 시작일
     private int period; //기간
-    private String url; //이미지 url
     private Goal.GoalStatus status; //목표 진행상태
 }

--- a/server/src/main/java/com/team1472/moas/goal/entity/Goal.java
+++ b/server/src/main/java/com/team1472/moas/goal/entity/Goal.java
@@ -30,11 +30,11 @@ public class Goal extends Auditable {
     @Column(nullable = false)
     private long monthlyPayment; //월 납입금
 
-    @Column(nullable = false)
+    @Column()
     private LocalDateTime paymentStart; //납입 시작일
 
-    @Column(nullable = false)
-    private int period = (int) Math.ceil((price-principle)/monthlyPayment); //납입 기간 = (목표금액 - 원금)/월 납입금
+    @Column()
+    private int period; //납입 기간 = (목표금액 - 원금)/월 납입금
 
     @Column(length = 1000)
     private String url; //이미지 url

--- a/server/src/main/java/com/team1472/moas/goal/entity/Goal.java
+++ b/server/src/main/java/com/team1472/moas/goal/entity/Goal.java
@@ -11,6 +11,7 @@ import java.time.LocalDateTime;
 
 @NoArgsConstructor
 @Getter
+@Setter
 @Entity
 public class Goal extends Auditable {
     @Id
@@ -21,22 +22,22 @@ public class Goal extends Auditable {
     private String goalName; //목표명
 
     @Column(nullable = false)
-    private long price; //가격
+    private long price; //목표 금액
 
     @Column(nullable = false)
     private long principle; //원금
 
     @Column(nullable = false)
-    private long monthly_payment; //월 납입금
+    private long monthlyPayment; //월 납입금
 
     @Column(nullable = false)
-    private LocalDateTime payment_start; //납입 시작일
+    private LocalDateTime paymentStart; //납입 시작일
 
     @Column(nullable = false)
-    private int period; //납입 기간
+    private int period = (int) Math.ceil((price-principle)/monthlyPayment); //납입 기간 = (목표금액 - 원금)/월 납입금
 
     @Column(length = 1000)
-    private String url;
+    private String url; //이미지 url
 
     @Enumerated(value = EnumType.STRING)
     private GoalStatus status = GoalStatus.PROGRESS; //진행중이 기본값

--- a/server/src/main/java/com/team1472/moas/goal/mapper/GoalMapper.java
+++ b/server/src/main/java/com/team1472/moas/goal/mapper/GoalMapper.java
@@ -1,0 +1,17 @@
+package com.team1472.moas.goal.mapper;
+
+import com.team1472.moas.goal.dto.GoalPatchRes;
+import com.team1472.moas.goal.dto.GoalPostRes;
+import com.team1472.moas.goal.dto.GoalRes;
+import com.team1472.moas.goal.entity.Goal;
+import org.mapstruct.Mapper;
+
+import java.util.List;
+
+@Mapper(componentModel = "spring")
+public interface GoalMapper {
+    Goal goalPostDtoToGoal(GoalPostRes goalPostRes);
+    Goal goalPatchDtoToGoal(GoalPatchRes goalPatchRes);
+    GoalRes goalToGoalResponseDto(Goal goal);
+    List<GoalRes> goalsToGoalResponseDtos(List<Goal> goals);
+}

--- a/server/src/main/java/com/team1472/moas/goal/repository/GoalRepository.java
+++ b/server/src/main/java/com/team1472/moas/goal/repository/GoalRepository.java
@@ -1,0 +1,10 @@
+package com.team1472.moas.goal.repository;
+
+import com.team1472.moas.goal.entity.Goal;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
+
+public interface GoalRepository extends JpaRepository<Goal, Long> {
+}

--- a/server/src/main/java/com/team1472/moas/goal/service/GoalService.java
+++ b/server/src/main/java/com/team1472/moas/goal/service/GoalService.java
@@ -44,7 +44,10 @@ public class GoalService{
         Optional.ofNullable(goal.getPrice()).ifPresent(price -> findGoal.setPrice(price));
         Optional.ofNullable(goal.getMonthlyPayment()).ifPresent(monthlyPayment -> findGoal.setMonthlyPayment(monthlyPayment));
         Optional.ofNullable(goal.getPaymentStart()).ifPresent(paymentStart -> findGoal.setPaymentStart(paymentStart));
-        Optional.ofNullable(goal.getPeriod()).ifPresent(period -> findGoal.setPeriod(period));
+
+        int period = (int) Math.ceil((goal.getPrice() - goal.getPrinciple()) / goal.getMonthlyPayment());
+        goal.setPeriod(period);
+
         //상태 변경 어떻게?
         Optional.ofNullable(goal.getStatus()).ifPresent(status -> findGoal.setStatus(status));
         Optional.ofNullable(goal.getUrl()).ifPresent(url -> findGoal.setUrl(url));

--- a/server/src/main/java/com/team1472/moas/goal/service/GoalService.java
+++ b/server/src/main/java/com/team1472/moas/goal/service/GoalService.java
@@ -18,7 +18,7 @@ import java.util.Optional;
 @Service
 @RequiredArgsConstructor
 @Transactional
-public class GoalService {
+public class GoalService{
     private final MemberRepository memberRepository;
     private final GoalRepository goalRepository;
 
@@ -27,12 +27,17 @@ public class GoalService {
         Member member = memberRepository.findById(memberId);
         goal.setMember(member);
 
+        //납입 기간(단위: 월) = {(목표금액 - 원금)/월 납입금}
+        int period = (int) Math.ceil((goal.getPrice() - goal.getPrinciple()) / goal.getMonthlyPayment());
+        goal.setPeriod(period);
+
         return goalRepository.save(goal);
     }
 
     //목표 수정
-    public Goal updateGoal(Goal goal) {
-        Goal findGoal = findVerifiedGoal(goal.getId());
+    public Goal updateGoal(Goal goal, long id) {
+        //Goal findGoal = findVerifiedGoal(goal.getId());
+        Goal findGoal = findVerifiedGoal(id);
 
         //리팩토링 필요
         Optional.ofNullable(goal.getGoalName()).ifPresent(goalName -> findGoal.setGoalName(goalName));

--- a/server/src/main/java/com/team1472/moas/goal/service/GoalService.java
+++ b/server/src/main/java/com/team1472/moas/goal/service/GoalService.java
@@ -1,0 +1,73 @@
+package com.team1472.moas.goal.service;
+
+import com.team1472.moas.exception.BusinessLogicException;
+import com.team1472.moas.exception.ExceptionCode;
+import com.team1472.moas.goal.entity.Goal;
+import com.team1472.moas.goal.repository.GoalRepository;
+import com.team1472.moas.member.entity.Member;
+import com.team1472.moas.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class GoalService {
+    private final MemberRepository memberRepository;
+    private final GoalRepository goalRepository;
+
+    //목표 생성
+    public Goal createGoal(Goal goal, long memberId) {
+        Member member = memberRepository.findById(memberId);
+        goal.setMember(member);
+
+        return goalRepository.save(goal);
+    }
+
+    //목표 수정
+    public Goal updateGoal(Goal goal) {
+        Goal findGoal = findVerifiedGoal(goal.getId());
+
+        //리팩토링 필요
+        Optional.ofNullable(goal.getGoalName()).ifPresent(goalName -> findGoal.setGoalName(goalName));
+        Optional.ofNullable(goal.getPrice()).ifPresent(price -> findGoal.setPrice(price));
+        Optional.ofNullable(goal.getMonthlyPayment()).ifPresent(monthlyPayment -> findGoal.setMonthlyPayment(monthlyPayment));
+        Optional.ofNullable(goal.getPaymentStart()).ifPresent(paymentStart -> findGoal.setPaymentStart(paymentStart));
+        Optional.ofNullable(goal.getPeriod()).ifPresent(period -> findGoal.setPeriod(period));
+        //상태 변경 어떻게?
+        Optional.ofNullable(goal.getStatus()).ifPresent(status -> findGoal.setStatus(status));
+        Optional.ofNullable(goal.getUrl()).ifPresent(url -> findGoal.setUrl(url));
+
+        return goalRepository.save(findGoal);
+    }
+
+    //목표 상세 조회
+    public Goal findGoal(long id) {
+        return findVerifiedGoal(id);
+    }
+
+    //목표 전체 조회 (List)
+    public List<Goal> findGoals() {
+        return goalRepository.findAll();
+    }
+
+    //목표 삭제
+    public void deleteGoal(long id) {
+        Goal findGoal = findVerifiedGoal(id);
+        goalRepository.delete(findGoal);
+    }
+
+    //id로 특정 목표가 존재하는지 찾아서 리턴
+    //존재하지 않을 시 에러 메세지 띄움
+    private Goal findVerifiedGoal(long id) {
+        Optional<Goal> optionalGoal = goalRepository.findById(id);
+        Goal findGoal = optionalGoal.orElseThrow(() -> new BusinessLogicException(ExceptionCode.GOAL_NOT_FOUND));
+        return findGoal;
+    }
+}

--- a/server/src/main/java/com/team1472/moas/member/repository/MemberRepository.java
+++ b/server/src/main/java/com/team1472/moas/member/repository/MemberRepository.java
@@ -1,0 +1,8 @@
+package com.team1472.moas.member.repository;
+
+import com.team1472.moas.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+    Member findById(long memberId);
+}

--- a/server/src/main/java/com/team1472/moas/member/service/MemberService.java
+++ b/server/src/main/java/com/team1472/moas/member/service/MemberService.java
@@ -1,0 +1,7 @@
+package com.team1472.moas.member.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class MemberService {
+}

--- a/server/src/main/java/com/team1472/moas/response/MultiResponse.java
+++ b/server/src/main/java/com/team1472/moas/response/MultiResponse.java
@@ -15,4 +15,8 @@ public class MultiResponse<T> {
         this.pageInfo = new PageInfo(page.getNumber() + 1,
                 page.getSize(), page.getTotalElements(), page.getTotalPages());
     }
+
+    public MultiResponse(List<T> data) {
+        this.data = data;
+    }
 }

--- a/server/src/main/java/com/team1472/moas/response/SingleResponse.java
+++ b/server/src/main/java/com/team1472/moas/response/SingleResponse.java
@@ -1,8 +1,10 @@
 package com.team1472.moas.response;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
+@AllArgsConstructor
 public class SingleResponse<T> {
     private T data;
 }


### PR DESCRIPTION
# 목표 도메인 CRUD 기본 기능 구현
## 주요 구현 내용
- 목표 등록 기능
- 목표 수정 기능
- 목표 상세 조회 기능
- 목표 전체 조회 기능 (List) : 페이지네이션 적용 X
- 목표 삭제 기능

### 상세 설명
목표명, 목표금액, 월 납입금액을 입력하면 납입 기간 자동으로 계산해서 리턴합니다. 
소수점 발생 시 무조건 올림하도록 구현하였습니다.
- 납입 기간(단위: 월) = (목표금액 - 원금) / 월 납입금액

## 추후 고려 사항
- 회원 도메인과 연결 필요
- Frontend 측에서 TODO DatePicker 사용할 시, Backend 측과 연결 방안 마련 필요
- GoalService updateGoal 코드 리팩토링 필요