### PR TITLE
[BE Feat] 적금 리스트 필터링 조회 기능 구현

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -30,6 +30,13 @@ dependencies {
     implementation 'org.mapstruct:mapstruct:1.5.1.Final'
     annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.1.Final'
     implementation 'com.google.code.gson:gson'
+
+    // QueryDSL
+    implementation "com.querydsl:querydsl-jpa:5.0.0"
+    annotationProcessor(
+            "javax.persistence:javax.persistence-api",
+            "javax.annotation:javax.annotation-api",
+            "com.querydsl:querydsl-apt:5.0.0:jpa")
 }
 
 tasks.named('test') {

--- a/server/src/main/java/com/team1472/moas/config/QueryDslConfig.java
+++ b/server/src/main/java/com/team1472/moas/config/QueryDslConfig.java
@@ -1,0 +1,19 @@
+package com.team1472.moas.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+@Configuration
+public class QueryDslConfig {
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/server/src/main/java/com/team1472/moas/installment_savings/controller/SavingProductsController.java
+++ b/server/src/main/java/com/team1472/moas/installment_savings/controller/SavingProductsController.java
@@ -1,0 +1,42 @@
+package com.team1472.moas.installment_savings.controller;
+
+import com.team1472.moas.installment_savings.dto.SavingProductRes;
+import com.team1472.moas.installment_savings.dto.SavingsFilteringReq;
+import com.team1472.moas.installment_savings.service.SavingProductsService;
+import com.team1472.moas.response.MultiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+import javax.validation.constraints.Positive;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/savings")
+@RequiredArgsConstructor
+@Validated
+public class SavingProductsController {
+    private final SavingProductsService savingProductsService;
+
+    /**
+     * 적금 정보 리스트 필터링 조회
+     */
+    @PostMapping
+    public ResponseEntity searchSavingProducts(@Positive @RequestParam("page") int page,
+                                               @Positive @RequestParam("size") int size,
+                                               @Valid @RequestBody SavingsFilteringReq savingsFilteringReq) {
+
+        Pageable pageable = PageRequest.of(page - 1, size);
+        Page<SavingProductRes> pageSavingProducts = savingProductsService.findSavingsProducts(pageable, savingsFilteringReq);
+
+        List<SavingProductRes> savingProducts = pageSavingProducts.getContent();
+
+        return new ResponseEntity(new MultiResponse<>(savingProducts, pageSavingProducts), HttpStatus.OK);
+    }
+}

--- a/server/src/main/java/com/team1472/moas/installment_savings/dto/SavingProductRes.java
+++ b/server/src/main/java/com/team1472/moas/installment_savings/dto/SavingProductRes.java
@@ -1,0 +1,43 @@
+package com.team1472.moas.installment_savings.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SavingProductRes {
+    private long savingsId; //적금 상품 id
+
+    private long interestId; //금리 id
+
+    private String korCoNm; //금융회사 명
+
+    private String finPrdtNm; //금융상품명
+
+    private String joinWay; //가입 방법
+
+    private String spclCnd; //우대 조건
+
+    private String joinDeny; //가입제한
+
+    private String joinMember; //가입 대상
+
+    private String etcNote; //기타 유의사항
+
+    private int maxLimit; //최고 한도
+
+    private String intrRateTypeNm; // 저축 금리 유형명
+
+    private String rsrvTypeNm; //적립 유형명
+
+    private String saveTrm; // 저축 기간(단위: 개월)
+
+    private String mtrtInt; //만기 후 이자율
+
+    private double intrRate; //저축 금리(소수점 2자리)
+
+    private double intrRate2; //최고 우대 금리(소수점 2자리)
+
+}

--- a/server/src/main/java/com/team1472/moas/installment_savings/dto/SavingsFilteringReq.java
+++ b/server/src/main/java/com/team1472/moas/installment_savings/dto/SavingsFilteringReq.java
@@ -1,0 +1,27 @@
+package com.team1472.moas.installment_savings.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.validation.constraints.Positive;
+import java.util.List;
+
+@Getter
+@Setter
+public class SavingsFilteringReq {
+    @Positive(message = "정확한 금액을 입력해주세요.")
+    private long monthlySavings; //월 납입 금액
+
+    private String saveTrm; //저축 희망 기간
+
+    @Positive(message = "정확한 금액을 입력해주세요.")
+    private long totalSavings; //총 저축 금액
+
+    private String rsrvType; //저축 방식 - 정액적립식: "S", 자유적립식: "F"
+
+    private List<String> finCoNoList; //은행 선택
+
+    private String intrRateType; //이자 계산 방식 - 단리: "S", 복리: "M"
+
+    private String joinDeny; //가입 대상 - 제한 없음: “1”, 서민전용: “2”, 일부제한: ”3”
+}

--- a/server/src/main/java/com/team1472/moas/installment_savings/repository/CustomSavingProductsRepository.java
+++ b/server/src/main/java/com/team1472/moas/installment_savings/repository/CustomSavingProductsRepository.java
@@ -1,0 +1,10 @@
+package com.team1472.moas.installment_savings.repository;
+
+import com.team1472.moas.installment_savings.dto.SavingProductRes;
+import com.team1472.moas.installment_savings.dto.SavingsFilteringReq;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface CustomSavingProductsRepository {
+    Page<SavingProductRes> findFilteringSavingProducts(Pageable pageable, SavingsFilteringReq savingsFilteringReq);
+}

--- a/server/src/main/java/com/team1472/moas/installment_savings/repository/CustomSavingProductsRepositoryImpl.java
+++ b/server/src/main/java/com/team1472/moas/installment_savings/repository/CustomSavingProductsRepositoryImpl.java
@@ -1,0 +1,88 @@
+package com.team1472.moas.installment_savings.repository;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.team1472.moas.installment_savings.dto.SavingProductRes;
+import com.team1472.moas.installment_savings.dto.SavingsFilteringReq;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+
+import static com.team1472.moas.installment_savings.entity.QInstallmentSavings.installmentSavings;
+import static com.team1472.moas.installment_savings.entity.QInterestRate.interestRate;
+
+@Repository
+@RequiredArgsConstructor
+public class CustomSavingProductsRepositoryImpl implements CustomSavingProductsRepository {
+    private final JPAQueryFactory jpaQueryFactory;
+
+    //적금 상품 필터링해서 조회
+    @Override
+    public Page<SavingProductRes> findFilteringSavingProducts(Pageable pageable, SavingsFilteringReq savingsFilteringReq) {
+        List<SavingProductRes> savings = jpaQueryFactory.select(
+                        Projections.constructor(SavingProductRes.class,
+                                installmentSavings.id,
+                                interestRate.id,
+                                installmentSavings.korCoNm,
+                                installmentSavings.finPrdtNm,
+                                installmentSavings.joinWay,
+                                installmentSavings.spclCnd,
+                                installmentSavings.joinDeny,
+                                installmentSavings.joinMember,
+                                installmentSavings.etcNote,
+                                installmentSavings.maxLimit,
+                                interestRate.intrRateTypeNm,
+                                interestRate.rsrvTypeNm,
+                                interestRate.saveTrm,
+                                installmentSavings.mtrtInt,
+                                interestRate.intrRate,
+                                interestRate.intrRate2))
+                .from(interestRate)
+                .join(installmentSavings).on(interestRate.finPrdtCd.eq(installmentSavings.finPrdtCd)).fetchJoin()
+                .where(checkCondition(savingsFilteringReq.getFinCoNoList(), installmentSavings.finCoNo::in), //주 거래 은행 필터링
+                        checkCondition(savingsFilteringReq.getSaveTrm(), interestRate.saveTrm::eq), //저축 희망 기간 필터링
+                        checkCondition(savingsFilteringReq.getRsrvType(), interestRate.rsrvType::eq), //적립 방식 필터링
+                        checkCondition(savingsFilteringReq.getIntrRateType(), interestRate.intrRateType::eq), //이자 적립 방식 필터링
+                        checkCondition(savingsFilteringReq.getJoinDeny(), installmentSavings.joinDeny::in)) //가입 대상 필터링
+                .orderBy(interestRate.intrRate.desc(), interestRate.intrRate2.desc())
+                .offset(pageable.getPageNumber()).limit(pageable.getPageSize())
+                .fetch();
+
+        //필터링 한 후 전체 데이터 개수
+        long totalCount = jpaQueryFactory
+                .from(interestRate)
+                .join(installmentSavings).on(interestRate.finPrdtCd.eq(installmentSavings.finPrdtCd)).fetchJoin()
+                .where(checkCondition(savingsFilteringReq.getFinCoNoList(), installmentSavings.finCoNo::in), //주 거래 은행 필터링
+                        checkCondition(savingsFilteringReq.getSaveTrm(), interestRate.saveTrm::eq), //저축 희망 기간 필터링
+                        checkCondition(savingsFilteringReq.getRsrvType(), interestRate.rsrvType::eq), //적립 방식 필터링
+                        checkCondition(savingsFilteringReq.getIntrRateType(), interestRate.intrRateType::eq), //이자 적립 방식 필터링
+                        checkCondition(savingsFilteringReq.getJoinDeny(), installmentSavings.joinDeny::in)) //가입 대상 필터링
+                .fetch().size();
+
+        return new PageImpl<>(savings, pageable, totalCount);
+
+    }
+
+    // 필터링 조건 존재 여부에 따라 where 조건 추가
+    private <T> BooleanExpression checkCondition(T value, Function<T, BooleanExpression> function) {
+        if (value instanceof String) { //value의 타입이 String인 경우 빈 문자열이 넘어오면 null 처리
+            if (value.equals("")) {
+                value = null;
+            }
+        } else if (value instanceof List) { //value의 타입이 List인 경우 빈 리스트가 넘어오면 null 처리
+            if (((List<?>) value).size() == 0) {
+                value = null;
+            }
+        }
+
+        return Optional.ofNullable(value).map(function).orElse(null);
+    }
+
+}

--- a/server/src/main/java/com/team1472/moas/installment_savings/repository/InterestRateRepository.java
+++ b/server/src/main/java/com/team1472/moas/installment_savings/repository/InterestRateRepository.java
@@ -3,5 +3,5 @@ package com.team1472.moas.installment_savings.repository;
 import com.team1472.moas.installment_savings.entity.InterestRate;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface InterestRateRepository extends JpaRepository<InterestRate, Long> {
+public interface InterestRateRepository extends JpaRepository<InterestRate, Long>, CustomSavingProductsRepository {
 }

--- a/server/src/main/java/com/team1472/moas/installment_savings/service/SavingProductsService.java
+++ b/server/src/main/java/com/team1472/moas/installment_savings/service/SavingProductsService.java
@@ -1,0 +1,21 @@
+package com.team1472.moas.installment_savings.service;
+
+import com.team1472.moas.installment_savings.dto.SavingProductRes;
+import com.team1472.moas.installment_savings.dto.SavingsFilteringReq;
+import com.team1472.moas.installment_savings.repository.InterestRateRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class SavingProductsService {
+    private final InterestRateRepository interestRateRepository;
+
+    public Page<SavingProductRes> findSavingsProducts(Pageable pageable, SavingsFilteringReq filter) {
+         Page<SavingProductRes> filteringSavingProducts = interestRateRepository.findFilteringSavingProducts(pageable, filter);
+
+        return filteringSavingProducts;
+    }
+}

--- a/server/src/main/java/com/team1472/moas/response/PageInfo.java
+++ b/server/src/main/java/com/team1472/moas/response/PageInfo.java
@@ -1,7 +1,9 @@
 package com.team1472.moas.response;
 
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 
+@Getter
 @AllArgsConstructor
 public class PageInfo {
     private int page;


### PR DESCRIPTION
# 적금 리스트 필터링 조회 기능
---
## 필터링 조건
- 월 저축 금액(monthlySavings)
- 저축 희망기간(saveTrm) => 단일 선택
  - 6개월: “6”, 12개월: “12”, 24개월: “24“, 36개월: “36”
- 총 저축금액(totalSavings)
- 적립방식(rsrvType)
  - 전체: null or "", 정액적립식: “S”, 자유적립식: “F”
- 주거래은행(finCoNoList) => 중복 선택 가능
    - 은행별 fin_co_no
- 이자계산방식(intrRateType)
    - 전체: null or "", 단리: “S”, 복리: “M”
- 가입대상(joinDeny) => 중복 가능
    - 전체: null or [], 제한 없음: “1”, 서민전용: “2”, 일부제한: ”3”

## 기능 구현 상세
다양한 필터링 조건과 중복 가능 여부로 인해 query string으로 인한 url이 매우 길어질 것을 고려하여 Post Method를 사용하여 request body를 사용하여 필터링 조건을 받을 수 있도록 처리하였습니다.
선택적으로 필터링 조건을 줄 수 있으므로 동적 쿼리를 작성하기 위해 QueryDSL을 이용하였습니다.
필터링 된 조회 결과를 바탕으로 index 기반 페이지네이션을 적용하였습니다.
무한로딩이 아닌  페이지 번호를 기준으로 페이지네이션을 하고, 실시간으로 업데이트 되는 데이터에 대한 조회가 아닌 단순 저장된 디비의 내용을 바탕으로 조회를 해오는 것이므로 index 기반 페이지네이션도 문제가 없을 것으로 판단하였습니다.

### Gradle 수정 사항
- QueryDSL dependency 추가

## 추후 개선 사항
- 이자 계산해서 리턴 여부 결정 필요
- 조건 join을 이용하기 때문에 엔티티에서 불필요한 필드 삭제
- page, size default 값 설정

---
Issue closes #14  