### PR TITLE
[BE Feat] 적금 조회 시 세후 이자 계산 구현

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -23,13 +23,13 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
-    annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    implementation 'org.mapstruct:mapstruct:1.5.1.Final'
-    annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.1.Final'
-    implementation 'com.google.code.gson:gson'
+    testImplementation("org.junit.vintage:junit-vintage-engine") {
+        exclude group: "org.hamcrest", module: "hamcrest-core"
+    }
 
     // QueryDSL
     implementation "com.querydsl:querydsl-jpa:5.0.0"
@@ -38,7 +38,8 @@ dependencies {
             "javax.annotation:javax.annotation-api",
             "com.querydsl:querydsl-apt:5.0.0:jpa")
 
-    implementation 'org.springdoc:springdoc-openapi-ui:1.6.14' //swagger 적용 위한 설정
+    //swagger 적용 위한 설정
+    implementation 'org.springdoc:springdoc-openapi-ui:1.6.14'
 
     //OAuth
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
@@ -46,20 +47,12 @@ dependencies {
     implementation 'org.apache.tomcat.embed:tomcat-embed-jasper'
     implementation 'javax.servlet:jstl'
 
-    //H2 로컬용
-//    runtimeOnly 'com.h2database:h2'
-
-    //Mysql 배포용
-    implementation 'mysql:mysql-connector-java'
-    //유효성 관련
-    implementation 'org.springframework.boot:spring-boot-starter-validation'
-
     //MapStruct
     implementation 'org.mapstruct:mapstruct:1.5.3.Final'
     annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.3.Final'
 
     //Json Mapper
-    implementation 'com.google.code.gson:gson:2.9.0'
+    implementation 'com.google.code.gson:gson'
     implementation 'com.googlecode.json-simple:json-simple:1.1.1'
 
     //JWT 관련
@@ -67,20 +60,11 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly	'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
-    //redis
-    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
-
     //log
     implementation (
-            'ch.qos.logback:logback-classic:1.2.3',
-            'ch.qos.logback:logback-core:1.2.3',
+            'ch.qos.logback:logback-classic:1.2.11',
+            'ch.qos.logback:logback-core:1.2.11',
     )
-
-    //test
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testImplementation("org.junit.vintage:junit-vintage-engine") {
-        exclude group: "org.hamcrest", module: "hamcrest-core"
-    }
 
 }
 

--- a/server/src/main/java/com/team1472/moas/installment_savings/controller/SavingProductsController.java
+++ b/server/src/main/java/com/team1472/moas/installment_savings/controller/SavingProductsController.java
@@ -33,10 +33,9 @@ public class SavingProductsController {
                                                @Valid @RequestBody SavingsFilteringReq savingsFilteringReq) {
 
         Pageable pageable = PageRequest.of(page - 1, size);
-        Page<SavingProductRes> pageSavingProducts = savingProductsService.findSavingsProducts(pageable, savingsFilteringReq);
+        MultiResponse response = savingProductsService.findSavingsProducts(pageable, savingsFilteringReq);
 
-        List<SavingProductRes> savingProducts = pageSavingProducts.getContent();
 
-        return new ResponseEntity(new MultiResponse<>(savingProducts, pageSavingProducts), HttpStatus.OK);
+        return new ResponseEntity(response, HttpStatus.OK);
     }
 }

--- a/server/src/main/java/com/team1472/moas/installment_savings/controller/SavingProductsController.java
+++ b/server/src/main/java/com/team1472/moas/installment_savings/controller/SavingProductsController.java
@@ -28,8 +28,8 @@ public class SavingProductsController {
      * 적금 정보 리스트 필터링 조회
      */
     @PostMapping
-    public ResponseEntity searchSavingProducts(@Positive @RequestParam("page") int page,
-                                               @Positive @RequestParam("size") int size,
+    public ResponseEntity searchSavingProducts(@Positive @RequestParam(value = "page", required = false, defaultValue = "1") int page,
+                                               @Positive @RequestParam(value = "size", required = false, defaultValue = "10") int size,
                                                @Valid @RequestBody SavingsFilteringReq savingsFilteringReq) {
 
         Pageable pageable = PageRequest.of(page - 1, size);

--- a/server/src/main/java/com/team1472/moas/installment_savings/dto/SavingProductRes.java
+++ b/server/src/main/java/com/team1472/moas/installment_savings/dto/SavingProductRes.java
@@ -3,6 +3,7 @@ package com.team1472.moas.installment_savings.dto;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
 @NoArgsConstructor
@@ -28,6 +29,8 @@ public class SavingProductRes {
 
     private int maxLimit; //최고 한도
 
+    private String intrRateType; // 저축 금리 유형
+
     private String intrRateTypeNm; // 저축 금리 유형명
 
     private String rsrvTypeNm; //적립 유형명
@@ -40,4 +43,29 @@ public class SavingProductRes {
 
     private double intrRate2; //최고 우대 금리(소수점 2자리)
 
+    @Setter
+    private long interestAmount; //세후 이자 금액 (세전 이자 금액 - 세금(15.4%))
+
+    public SavingProductRes(long savingsId, long interestId, String korCoNm, String finPrdtNm, String joinWay,
+                            String spclCnd, String joinDeny, String joinMember, String etcNote, int maxLimit,
+                            String intrRateType, String intrRateTypeNm, String rsrvTypeNm, String saveTrm,
+                            String mtrtInt, double intrRate, double intrRate2) {
+        this.savingsId = savingsId;
+        this.interestId = interestId;
+        this.korCoNm = korCoNm;
+        this.finPrdtNm = finPrdtNm;
+        this.joinWay = joinWay;
+        this.spclCnd = spclCnd;
+        this.joinDeny = joinDeny;
+        this.joinMember = joinMember;
+        this.etcNote = etcNote;
+        this.maxLimit = maxLimit;
+        this.intrRateType = intrRateType;
+        this.intrRateTypeNm = intrRateTypeNm;
+        this.rsrvTypeNm = rsrvTypeNm;
+        this.saveTrm = saveTrm;
+        this.mtrtInt = mtrtInt;
+        this.intrRate = intrRate;
+        this.intrRate2 = intrRate2;
+    }
 }

--- a/server/src/main/java/com/team1472/moas/installment_savings/dto/SavingsFilteringReq.java
+++ b/server/src/main/java/com/team1472/moas/installment_savings/dto/SavingsFilteringReq.java
@@ -14,9 +14,6 @@ public class SavingsFilteringReq {
 
     private String saveTrm; //저축 희망 기간
 
-    @Positive(message = "정확한 금액을 입력해주세요.")
-    private long totalSavings; //총 저축 금액
-
     private String rsrvType; //저축 방식 - 정액적립식: "S", 자유적립식: "F"
 
     private List<String> finCoNoList; //은행 선택

--- a/server/src/main/java/com/team1472/moas/installment_savings/repository/CustomSavingProductsRepositoryImpl.java
+++ b/server/src/main/java/com/team1472/moas/installment_savings/repository/CustomSavingProductsRepositoryImpl.java
@@ -38,6 +38,7 @@ public class CustomSavingProductsRepositoryImpl implements CustomSavingProductsR
                                 installmentSavings.joinMember,
                                 installmentSavings.etcNote,
                                 installmentSavings.maxLimit,
+                                interestRate.intrRateType,
                                 interestRate.intrRateTypeNm,
                                 interestRate.rsrvTypeNm,
                                 interestRate.saveTrm,
@@ -50,7 +51,9 @@ public class CustomSavingProductsRepositoryImpl implements CustomSavingProductsR
                         checkCondition(savingsFilteringReq.getSaveTrm(), interestRate.saveTrm::eq), //저축 희망 기간 필터링
                         checkCondition(savingsFilteringReq.getRsrvType(), interestRate.rsrvType::eq), //적립 방식 필터링
                         checkCondition(savingsFilteringReq.getIntrRateType(), interestRate.intrRateType::eq), //이자 적립 방식 필터링
-                        checkCondition(savingsFilteringReq.getJoinDeny(), installmentSavings.joinDeny::in)) //가입 대상 필터링
+                        checkCondition(savingsFilteringReq.getJoinDeny(), installmentSavings.joinDeny::in), //가입 대상 필터링
+                        (installmentSavings.maxLimit.goe(savingsFilteringReq.getMonthlySavings())
+                                .or(installmentSavings.maxLimit.eq(0)))) //월 납입 한도 필터링
                 .orderBy(interestRate.intrRate.desc(), interestRate.intrRate2.desc())
                 .offset(pageable.getPageNumber()).limit(pageable.getPageSize())
                 .fetch();
@@ -63,7 +66,9 @@ public class CustomSavingProductsRepositoryImpl implements CustomSavingProductsR
                         checkCondition(savingsFilteringReq.getSaveTrm(), interestRate.saveTrm::eq), //저축 희망 기간 필터링
                         checkCondition(savingsFilteringReq.getRsrvType(), interestRate.rsrvType::eq), //적립 방식 필터링
                         checkCondition(savingsFilteringReq.getIntrRateType(), interestRate.intrRateType::eq), //이자 적립 방식 필터링
-                        checkCondition(savingsFilteringReq.getJoinDeny(), installmentSavings.joinDeny::in)) //가입 대상 필터링
+                        checkCondition(savingsFilteringReq.getJoinDeny(), installmentSavings.joinDeny::in), //가입 대상 필터링
+                        (installmentSavings.maxLimit.goe(savingsFilteringReq.getMonthlySavings())
+                                .or(installmentSavings.maxLimit.eq(0)))) //월 납입 한도 필터링
                 .fetch().size();
 
         return new PageImpl<>(savings, pageable, totalCount);

--- a/server/src/main/java/com/team1472/moas/installment_savings/service/SavingProductsService.java
+++ b/server/src/main/java/com/team1472/moas/installment_savings/service/SavingProductsService.java
@@ -3,19 +3,73 @@ package com.team1472.moas.installment_savings.service;
 import com.team1472.moas.installment_savings.dto.SavingProductRes;
 import com.team1472.moas.installment_savings.dto.SavingsFilteringReq;
 import com.team1472.moas.installment_savings.repository.InterestRateRepository;
+import com.team1472.moas.response.MultiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class SavingProductsService {
     private final InterestRateRepository interestRateRepository;
 
-    public Page<SavingProductRes> findSavingsProducts(Pageable pageable, SavingsFilteringReq filter) {
-         Page<SavingProductRes> filteringSavingProducts = interestRateRepository.findFilteringSavingProducts(pageable, filter);
+    public MultiResponse findSavingsProducts(Pageable pageable, SavingsFilteringReq filter) {
+         Page<SavingProductRes> pageSavingProduct = interestRateRepository.findFilteringSavingProducts(pageable, filter);
 
-        return filteringSavingProducts;
+        // 이자율 계산
+        List<SavingProductRes> savingProducts = pageSavingProduct.getContent();
+
+        for (SavingProductRes savingProduct : savingProducts) {
+            long interestAmount = calculateInterestAmount(savingProduct, filter.getMonthlySavings());
+            savingProduct.setInterestAmount(interestAmount);
+        }
+
+        return new MultiResponse(savingProducts, pageSavingProduct);
     }
+
+    //이자 금액 계산
+    private long calculateInterestAmount(SavingProductRes savingProduct, long money) {
+        long pretaxInterest = 0;
+
+        if (savingProduct.getIntrRateType().equals("S")) { //단리 계산
+            pretaxInterest =  calculateSimpleInterest(money, savingProduct.getIntrRate(), savingProduct.getSaveTrm());
+
+        } else { //복리 계산
+            pretaxInterest =  calculateCompoundInterest(money, savingProduct.getIntrRate(), savingProduct.getSaveTrm());
+        }
+
+        long tax = calculateTax(pretaxInterest); //세금 계산
+
+        return pretaxInterest - tax;
+    }
+
+    //단리 계산
+    private long calculateSimpleInterest(long money, double interest, String period) {
+        int years = Integer.parseInt(period);
+
+        return Math.round((money * interest * 0.01 * (years + 1) * years / 2) / 12);
+    }
+
+    //복리 계산
+    private long calculateCompoundInterest(long money, double interest, String period) {
+        int years = Integer.parseInt(period);
+
+        return Math.round(money * (1 + interest * 0.01 / 12) * (Math.pow((1 + interest * 0.01 / 12), years) - 1) / (interest * 0.01 / 12)) - money * years;
+    }
+
+    //이자 세금 계산
+    private long calculateTax(long interest) {
+        double tax = interest * 0.154;
+        int firstDecimalPlace = (int) (((long)(tax * 10)) % 10);
+
+        if (firstDecimalPlace > 5) {
+            return (long) (Math.floor(tax) + 1);
+        }
+
+        return (long) Math.floor(tax);
+    }
+
 }


### PR DESCRIPTION
# 적금 정보 리스트 필터링 조회 기능
---
## 구현 내용
- 적금 정보 리스트  필터링 조회 API 호출 시 page = 1, size = 10으로 기본 값 설정
- 적금 조회 시 월 납입 한도와 사용자가 입력한 월 납입 희망 금액 비교하는 필터링 추가
- 적금 조회 시 request body로 받는 총 납입 금액 삭제
- 적금 조회 시 월 납입 희망 금액에 따른 세후 이자 계산 추가

### 세후 이자 계산 세부 구현 사항
IntrRateType 필드 값에 따라 계산
- "S": 단리 계산
- "M": 복리 계산

세금 15.4%를 뺀 세후 이자 금액 리턴
우리 은행 금융 계산기 기준으로 계산 수행

약간의 오차가 있을 수 있으나 최대한 오차를 줄이기 위해
세금 계산 시 1의 자리가 5초과인 경우에 한해서 올림 수행

## 그 외
중복 dependency 제거

----
우리 은행 금융 계산기 : https://spot.wooribank.com/pot/Dream?withyou=CMBBS0086&cc=c006244:c006282#none

Issue closes #31 