### PR TITLE
[BE Refactor] Open Api 적금 상품 조회 후 DB 저장 기능 리팩터링

### DIFF
--- a/server/src/main/java/com/team1472/moas/installment_savings/controller/OpenApiController.java
+++ b/server/src/main/java/com/team1472/moas/installment_savings/controller/OpenApiController.java
@@ -44,6 +44,7 @@ public class OpenApiController {
      * 매일 새벽 4시 자동 업데이트
      */
     @Scheduled(cron = "0 0 4 * * ?") // 매일 새벽 4시 자동 업데이트
+    @GetMapping("/refresh")
     public void deleteAndSaveInstallmentSavingsInfo() throws IOException {
         log.info("적금 정보 자동 업데이트 시작");
         openApiService.deleteAllData();

--- a/server/src/main/java/com/team1472/moas/installment_savings/entity/InstallmentSavings.java
+++ b/server/src/main/java/com/team1472/moas/installment_savings/entity/InstallmentSavings.java
@@ -5,8 +5,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
-import java.util.ArrayList;
-import java.util.List;
 
 @Entity
 @Getter
@@ -42,8 +40,5 @@ public class InstallmentSavings {
     private String etcNote; //기타 유의사항
 
     private int maxLimit; //최고 한도
-
-    @OneToMany(mappedBy = "installmentSavings", cascade = {CascadeType.PERSIST, CascadeType.REMOVE})
-    private List<InterestRate> interestRates = new ArrayList<>();
 
 }

--- a/server/src/main/java/com/team1472/moas/installment_savings/entity/InterestRate.java
+++ b/server/src/main/java/com/team1472/moas/installment_savings/entity/InterestRate.java
@@ -15,8 +15,6 @@ public class InterestRate {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private String finCoNo; //금융 회사 코드
-
     private String finPrdtCd; //금융 상품 코드 => FK로 사용
 
     private String intrRateType; // 저축 금리 유형
@@ -32,13 +30,5 @@ public class InterestRate {
     private double intrRate; //저축 금리(소수점 2자리)
 
     private double intrRate2; //최고 우대 금리(소수점 2자리)
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "INSTALLMENTSAVINGS_ID")
-    private InstallmentSavings installmentSavings;
-
-    public void addInstallmentSavings(InstallmentSavings installmentSavings) {
-        this.installmentSavings = installmentSavings;
-    }
 
 }

--- a/server/src/main/java/com/team1472/moas/installment_savings/service/OpenApiService.java
+++ b/server/src/main/java/com/team1472/moas/installment_savings/service/OpenApiService.java
@@ -10,10 +10,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
 
 @Slf4j
 @Service
@@ -42,12 +40,12 @@ public class OpenApiService {
 
         JsonArray baseList = result.get("baseList").getAsJsonArray(); //적금 기본 정보 리스트
         List<InstallmentSavings> savingsList = parseInstallmentSavingsInfo(baseList, gson);
-        installmentSavingsRepository.saveAll(savingsList);
 
         JsonArray optionList = result.get("optionList").getAsJsonArray(); //적금 이자율에 대한 정보 리스트
         List<InterestRate> interestRateList = parseInterestRateInfo(optionList, gson);
-        interestRateRepository.saveAll(interestRateList);
 
+        installmentSavingsRepository.saveAll(savingsList);
+        interestRateRepository.saveAll(interestRateList);
 
         return totalPageNum;
     }
@@ -73,21 +71,9 @@ public class OpenApiService {
 
     //적금 상품의 이자율 정보 파싱
     private List<InterestRate> parseInterestRateInfo(JsonArray optionList, Gson gson) {
-        List<InterestRate> interestRateList = new ArrayList<>();
+        InterestRate[] interestRates = gson.fromJson(optionList, InterestRate[].class);
 
-        for (int i = 0; i < optionList.size(); i++) {
-            JsonObject data = (JsonObject) optionList.get(i);
-
-            InterestRate interestRate = gson.fromJson(data, InterestRate.class);
-            Optional<InstallmentSavings> optSavings = installmentSavingsRepository.findByfinPrdtCd(interestRate.getFinPrdtCd());
-
-            optSavings.ifPresent(savings -> {
-                interestRate.addInstallmentSavings(savings);
-                interestRateList.add(interestRate);
-            });
-        }
-
-        return interestRateList;
+        return Arrays.asList(interestRates);
     }
 
     // 적금, 이자 정보 데이터 전부 삭제


### PR DESCRIPTION
# Open Api 적금 상품 조회 후 DB 저장 기능 1차 리팩터링
---
- InstallmentSavings, InterestRate 엔티티 연관 관계 삭제
   - InstallmentSavings는 List<InterestRate> 삭제
   - InterestRate는 InstallmentSavings 필드 삭제
      - 위 필드 삭제로 인한 DB 저장 로직 단순화
      - 기존의 Installement 객체를 얻어오기 위한 조회 로직 삭제 => 성능 향상

### 그 외
- 적금 정보 리프레시 API 추가
  - /open-api/refresh 
  - 기존 DB에 저장되어 있는 적금 정보를 삭제하고 Open Api를 통해 새로 받아오는 적금 정보 DB 저장

## 추후 계획
- Open Api 호출 webClient로 수정 
- 적금 정보 DB 저장 시 bulk insert 불가능 대안 찾기

Issue closes #34 