### PR TITLE
[BE Feat] 관심 적금 등록 기능 구현

### DIFF
--- a/server/src/main/java/com/team1472/moas/like_savings/controller/LikeSavingsController.java
+++ b/server/src/main/java/com/team1472/moas/like_savings/controller/LikeSavingsController.java
@@ -1,0 +1,31 @@
+package com.team1472.moas.like_savings.controller;
+
+import com.team1472.moas.like_savings.dto.RegisterLikeSavingProductReq;
+import com.team1472.moas.like_savings.entity.LikeSavings;
+import com.team1472.moas.like_savings.mapper.LikeSavingsMapper;
+import com.team1472.moas.like_savings.service.LikeSavingsService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/{memberId}/savings/interest")
+@RequiredArgsConstructor
+public class LikeSavingsController {
+    private final LikeSavingsService likeSavingsService;
+    private final LikeSavingsMapper mapper;
+
+    /**
+     * 관심 적금 등록
+     */
+    @PostMapping
+    public ResponseEntity likeSavingProduct(@PathVariable("memberId") long memberId,
+                                            @RequestBody RegisterLikeSavingProductReq registerLikeSavingProductReq) {
+
+
+        LikeSavings likeSavings = likeSavingsService.RegisterInterestInSavings(memberId, mapper.likeSavingProductReqToLikeSavings(registerLikeSavingProductReq));
+
+        return new ResponseEntity(mapper.likeSavingsToLikeSavingsProductRes(likeSavings), HttpStatus.CREATED);
+    }
+}

--- a/server/src/main/java/com/team1472/moas/like_savings/controller/LikeSavingsController.java
+++ b/server/src/main/java/com/team1472/moas/like_savings/controller/LikeSavingsController.java
@@ -7,11 +7,15 @@ import com.team1472.moas.like_savings.service.LikeSavingsService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
 
 @RestController
 @RequestMapping("/api/{memberId}/savings/interest")
 @RequiredArgsConstructor
+@Validated
 public class LikeSavingsController {
     private final LikeSavingsService likeSavingsService;
     private final LikeSavingsMapper mapper;
@@ -21,7 +25,7 @@ public class LikeSavingsController {
      */
     @PostMapping
     public ResponseEntity likeSavingProduct(@PathVariable("memberId") long memberId,
-                                            @RequestBody RegisterLikeSavingProductReq registerLikeSavingProductReq) {
+                                            @Valid @RequestBody RegisterLikeSavingProductReq registerLikeSavingProductReq) {
 
 
         LikeSavings likeSavings = likeSavingsService.RegisterInterestInSavings(memberId, mapper.likeSavingProductReqToLikeSavings(registerLikeSavingProductReq));

--- a/server/src/main/java/com/team1472/moas/like_savings/dto/RegisterLikeSavingProductReq.java
+++ b/server/src/main/java/com/team1472/moas/like_savings/dto/RegisterLikeSavingProductReq.java
@@ -1,0 +1,14 @@
+package com.team1472.moas.like_savings.dto;
+
+import lombok.Getter;
+
+@Getter
+public class RegisterLikeSavingProductReq {
+    private String finPrdtCd; //금융 상품 코드 => FK로 사용
+
+    private String intrRateType; // 저축 금리 유형
+
+    private String rsrvType; //적립 유형
+
+    private String saveTrm; // 저축 기간(단위: 개월)
+}

--- a/server/src/main/java/com/team1472/moas/like_savings/dto/RegisterLikeSavingProductReq.java
+++ b/server/src/main/java/com/team1472/moas/like_savings/dto/RegisterLikeSavingProductReq.java
@@ -2,13 +2,22 @@ package com.team1472.moas.like_savings.dto;
 
 import lombok.Getter;
 
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
+
 @Getter
 public class RegisterLikeSavingProductReq {
+    @NotBlank
     private String finPrdtCd; //금융 상품 코드 => FK로 사용
 
+    @NotBlank
+    @Pattern(regexp = "^[SF]$", message = "입력 형식에 맞지 않습니다.")
     private String intrRateType; // 저축 금리 유형
 
+    @NotBlank
+    @Pattern(regexp = "^[SM]$",message = "입력 형식에 맞지 않습니다.")
     private String rsrvType; //적립 유형
 
+    @NotBlank
     private String saveTrm; // 저축 기간(단위: 개월)
 }

--- a/server/src/main/java/com/team1472/moas/like_savings/dto/RegisterLikeSavingProductRes.java
+++ b/server/src/main/java/com/team1472/moas/like_savings/dto/RegisterLikeSavingProductRes.java
@@ -1,0 +1,25 @@
+package com.team1472.moas.like_savings.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class RegisterLikeSavingProductRes {
+    private long LikeId;
+
+    private long memberId;
+
+    private String finPrdtCd; //금융 상품 코드 => FK로 사용
+
+    private String intrRateType; // 저축 금리 유형
+
+    private String rsrvType; //적립 유형
+
+    private String saveTrm; // 저축 기간(단위: 개월)
+
+}

--- a/server/src/main/java/com/team1472/moas/like_savings/entity/LikeSavings.java
+++ b/server/src/main/java/com/team1472/moas/like_savings/entity/LikeSavings.java
@@ -1,0 +1,37 @@
+package com.team1472.moas.like_savings.entity;
+
+import com.team1472.moas.member.entity.Member;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class LikeSavings {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long Id;
+
+    private String finPrdtCd; //금융 상품 코드 => FK로 사용
+
+    private String intrRateType; // 저축 금리 유형
+
+    private String rsrvType; //적립 유형
+
+    private String saveTrm; // 저축 기간(단위: 개월)
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "MEMBER_ID")
+    private Member member;
+
+    public void addMember(Member member) {
+        this.member = member;
+    }
+
+}

--- a/server/src/main/java/com/team1472/moas/like_savings/mapper/LikeSavingsMapper.java
+++ b/server/src/main/java/com/team1472/moas/like_savings/mapper/LikeSavingsMapper.java
@@ -1,0 +1,22 @@
+package com.team1472.moas.like_savings.mapper;
+
+import com.team1472.moas.like_savings.dto.RegisterLikeSavingProductReq;
+import com.team1472.moas.like_savings.dto.RegisterLikeSavingProductRes;
+import com.team1472.moas.like_savings.entity.LikeSavings;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface LikeSavingsMapper {
+     LikeSavings likeSavingProductReqToLikeSavings(RegisterLikeSavingProductReq registerLikeSavingProductReq);
+
+     default RegisterLikeSavingProductRes likeSavingsToLikeSavingsProductRes(LikeSavings likeSavings) {
+          return new RegisterLikeSavingProductRes(
+                  likeSavings.getId(),
+                  likeSavings.getMember().getId(),
+                  likeSavings.getFinPrdtCd(),
+                  likeSavings.getIntrRateType(),
+                  likeSavings.getRsrvType(),
+                  likeSavings.getSaveTrm()
+          );
+     }
+}

--- a/server/src/main/java/com/team1472/moas/like_savings/repository/LikeSavingsRepository.java
+++ b/server/src/main/java/com/team1472/moas/like_savings/repository/LikeSavingsRepository.java
@@ -1,0 +1,7 @@
+package com.team1472.moas.like_savings.repository;
+
+import com.team1472.moas.like_savings.entity.LikeSavings;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LikeSavingsRepository extends JpaRepository<LikeSavings, Long> {
+}

--- a/server/src/main/java/com/team1472/moas/like_savings/service/LikeSavingsService.java
+++ b/server/src/main/java/com/team1472/moas/like_savings/service/LikeSavingsService.java
@@ -1,0 +1,23 @@
+package com.team1472.moas.like_savings.service;
+
+import com.team1472.moas.like_savings.entity.LikeSavings;
+import com.team1472.moas.like_savings.repository.LikeSavingsRepository;
+import com.team1472.moas.member.entity.Member;
+import com.team1472.moas.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class LikeSavingsService {
+    private final LikeSavingsRepository likeSavingsRepository;
+    private final MemberService memberService;
+
+    //관심 적금 등록
+    public LikeSavings RegisterInterestInSavings(long memberId, LikeSavings likeSavings) {
+        Member member = memberService.findMember(memberId);
+        likeSavings.addMember(member);
+
+        return likeSavingsRepository.save(likeSavings);
+    }
+}

--- a/server/src/main/java/com/team1472/moas/like_savings/service/LikeSavingsService.java
+++ b/server/src/main/java/com/team1472/moas/like_savings/service/LikeSavingsService.java
@@ -6,14 +6,17 @@ import com.team1472.moas.member.entity.Member;
 import com.team1472.moas.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class LikeSavingsService {
     private final LikeSavingsRepository likeSavingsRepository;
     private final MemberService memberService;
 
     //관심 적금 등록
+    @Transactional
     public LikeSavings RegisterInterestInSavings(long memberId, LikeSavings likeSavings) {
         Member member = memberService.findMember(memberId);
         likeSavings.addMember(member);


### PR DESCRIPTION
# 관심 적금 등록 기능
---
- 현재 적금 정보가 하루에 한번씩 삭제 후 다시 저장되는 식으로 재로드 되는 방식
- 단순 증가되는 PK인 ID 값을 사용할 수 없는 문제 발생

## 상세 구현
-  finPrdtCd
-  intrRateType
-  rsrvType
-  saveTrm
네가지 값을 이용하면 특정 적금 정보를 판별 가능하기 때문에 해당 정보를 저장해서 조회 시 사용할 예정