### PR TITLE
[BE Feat] 관심 적금 삭제 기능 구현

### DIFF
--- a/server/src/main/java/com/team1472/moas/exception/ExceptionCode.java
+++ b/server/src/main/java/com/team1472/moas/exception/ExceptionCode.java
@@ -8,7 +8,8 @@ public enum ExceptionCode {
     MEMBER_NOT_EXISTS(404, "멤버가 존재하지 않습니다"),
     EMAIL_ALREADY_EXISTS(404, "중복된 이메일입니다."),
 
-    GOAL_NOT_FOUND(404,"해당 목표를 찾을 수 없습니다.");
+    GOAL_NOT_FOUND(404,"해당 목표를 찾을 수 없습니다."),
+    LIKE_SAVINGS_NOT_FOUND(404, "해당 관심 적금을 찾을 수 없습니다.");
 
 
     private int status;

--- a/server/src/main/java/com/team1472/moas/like_savings/controller/LikeSavingsController.java
+++ b/server/src/main/java/com/team1472/moas/like_savings/controller/LikeSavingsController.java
@@ -11,9 +11,10 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import javax.validation.constraints.Positive;
 
 @RestController
-@RequestMapping("/api/{memberId}/savings/interest")
+@RequestMapping("/api/{member-id}/savings/interest")
 @RequiredArgsConstructor
 @Validated
 public class LikeSavingsController {
@@ -22,14 +23,32 @@ public class LikeSavingsController {
 
     /**
      * 관심 적금 등록
+     * @param memberId
+     * @param registerLikeSavingProductReq
+     * @return ResponseEntity
      */
     @PostMapping
-    public ResponseEntity likeSavingProduct(@PathVariable("memberId") long memberId,
+    public ResponseEntity likeSavingProduct(@Positive @PathVariable("member-id") long memberId,
                                             @Valid @RequestBody RegisterLikeSavingProductReq registerLikeSavingProductReq) {
 
 
         LikeSavings likeSavings = likeSavingsService.RegisterInterestInSavings(memberId, mapper.likeSavingProductReqToLikeSavings(registerLikeSavingProductReq));
 
         return new ResponseEntity(mapper.likeSavingsToLikeSavingsProductRes(likeSavings), HttpStatus.CREATED);
+    }
+
+    /**
+     * 관심 적금 삭제
+     * @param memberId
+     * @param interestId
+     * @return ResponseEntity
+     */
+    @DeleteMapping("/{like-saving-id}")
+    public ResponseEntity deleteLikeSavingProduct(@Positive @PathVariable("member-id") long memberId,
+                                                  @Positive @PathVariable("like-saving-id") long interestId) {
+
+        likeSavingsService.deleteLikeSavingProduct(memberId, interestId);
+
+        return new ResponseEntity("성공적으로 삭제되었습니다.", HttpStatus.OK);
     }
 }

--- a/server/src/main/java/com/team1472/moas/like_savings/repository/CustomLikeSavingsRepository.java
+++ b/server/src/main/java/com/team1472/moas/like_savings/repository/CustomLikeSavingsRepository.java
@@ -1,0 +1,10 @@
+package com.team1472.moas.like_savings.repository;
+
+import com.team1472.moas.like_savings.entity.LikeSavings;
+
+import java.util.Optional;
+
+public interface CustomLikeSavingsRepository {
+    //관심 적금 아이디와 회원 아이디가 일치하는 관심 적금 정보 조회
+    Optional<LikeSavings> findByLikeSavingIdAndMemberId(long likeSavingId, long memberId);
+}

--- a/server/src/main/java/com/team1472/moas/like_savings/repository/CustomLikeSavingsRepositoryImpl.java
+++ b/server/src/main/java/com/team1472/moas/like_savings/repository/CustomLikeSavingsRepositoryImpl.java
@@ -1,0 +1,25 @@
+package com.team1472.moas.like_savings.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.team1472.moas.like_savings.entity.LikeSavings;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+import static com.team1472.moas.like_savings.entity.QLikeSavings.likeSavings;
+
+@Repository
+@RequiredArgsConstructor
+public class CustomLikeSavingsRepositoryImpl implements CustomLikeSavingsRepository {
+    private final JPAQueryFactory jpaQueryFactory;
+
+    //관심 적금 아이디와 회원 아이디가 일치하는 관심 적금 정보 조회
+    @Override
+    public Optional<LikeSavings> findByLikeSavingIdAndMemberId(long likeSavingId, long memberId) {
+        return Optional.ofNullable(jpaQueryFactory.selectFrom(likeSavings)
+                .where(likeSavings.Id.eq(likeSavingId),
+                        likeSavings.member.id.eq(memberId))
+                .fetchOne());
+    }
+}

--- a/server/src/main/java/com/team1472/moas/like_savings/repository/LikeSavingsRepository.java
+++ b/server/src/main/java/com/team1472/moas/like_savings/repository/LikeSavingsRepository.java
@@ -3,5 +3,5 @@ package com.team1472.moas.like_savings.repository;
 import com.team1472.moas.like_savings.entity.LikeSavings;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface LikeSavingsRepository extends JpaRepository<LikeSavings, Long> {
+public interface LikeSavingsRepository extends JpaRepository<LikeSavings, Long>, CustomLikeSavingsRepository {
 }

--- a/server/src/main/java/com/team1472/moas/like_savings/service/LikeSavingsService.java
+++ b/server/src/main/java/com/team1472/moas/like_savings/service/LikeSavingsService.java
@@ -1,5 +1,7 @@
 package com.team1472.moas.like_savings.service;
 
+import com.team1472.moas.exception.BusinessLogicException;
+import com.team1472.moas.exception.ExceptionCode;
 import com.team1472.moas.like_savings.entity.LikeSavings;
 import com.team1472.moas.like_savings.repository.LikeSavingsRepository;
 import com.team1472.moas.member.entity.Member;
@@ -10,17 +12,29 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
+@Transactional
 public class LikeSavingsService {
     private final LikeSavingsRepository likeSavingsRepository;
     private final MemberService memberService;
 
     //관심 적금 등록
-    @Transactional
     public LikeSavings RegisterInterestInSavings(long memberId, LikeSavings likeSavings) {
         Member member = memberService.findMember(memberId);
         likeSavings.addMember(member);
 
         return likeSavingsRepository.save(likeSavings);
+    }
+
+    //관심 적금 삭제
+    public void deleteLikeSavingProduct(long memberId, long interestId) {
+        LikeSavings findLikeSavings = verifyExistsLikeSavingsOfMember(interestId, memberId);
+        likeSavingsRepository.delete(findLikeSavings);
+    }
+
+    //해당 멤버가 관심 등록한 적금인지 확인
+    private LikeSavings verifyExistsLikeSavingsOfMember(long interestId, long memberId) {
+
+        return likeSavingsRepository.findByLikeSavingIdAndMemberId(interestId, memberId)
+                .orElseThrow(() -> new BusinessLogicException(ExceptionCode.LIKE_SAVINGS_NOT_FOUND));
     }
 }


### PR DESCRIPTION
# 관심 적금 삭제 기능 구현
---
- 회원 아이디와 관심 적금 등록 아이디를 이용해서 관심 등록이 되어 있는지 확인 후 삭제

## 추후 개선 사항
- 단순 memberId만 사용하는 것이 아닌 회원 인증 로직을 추가할 예정

---
Issue closes #42 