### PR TITLE
[BE MISC] 관심 적금 도메인 token 적용

### DIFF
--- a/server/src/main/java/com/team1472/moas/like_savings/controller/LikeSavingsController.java
+++ b/server/src/main/java/com/team1472/moas/like_savings/controller/LikeSavingsController.java
@@ -5,6 +5,7 @@ import com.team1472.moas.like_savings.dto.RegisterLikeSavingProductReq;
 import com.team1472.moas.like_savings.entity.LikeSavings;
 import com.team1472.moas.like_savings.mapper.LikeSavingsMapper;
 import com.team1472.moas.like_savings.service.LikeSavingsService;
+import com.team1472.moas.member.service.MemberService;
 import com.team1472.moas.response.MultiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -19,30 +20,31 @@ import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 import javax.validation.constraints.Positive;
+import java.security.Principal;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/{member-id}/savings/interest")
+@RequestMapping("/api/savings/interest")
 @RequiredArgsConstructor
 @Validated
 @Tag(name = "LikeSavings", description = "관심 적금 API")
 public class LikeSavingsController {
     private final LikeSavingsService likeSavingsService;
+    private final MemberService memberService;
     private final LikeSavingsMapper mapper;
 
     /**
      * 관심 적금 등록
      *
-     * @param memberId
+     * @param principal
      * @param registerLikeSavingProductReq
      * @return ResponseEntity
      */
     @Operation(summary = "관심 적금 등록")
     @PostMapping
-    public ResponseEntity likeSavingProduct(@Positive @PathVariable("member-id") long memberId,
-                                            @Valid @RequestBody RegisterLikeSavingProductReq registerLikeSavingProductReq) {
+    public ResponseEntity likeSavingProduct(Principal principal, @Valid @RequestBody RegisterLikeSavingProductReq registerLikeSavingProductReq) {
 
-
+        long memberId = memberService.findMemberId(principal.getName());
         LikeSavings likeSavings = likeSavingsService.RegisterInterestInSavings(memberId, mapper.likeSavingProductReqToLikeSavings(registerLikeSavingProductReq));
 
         return new ResponseEntity(mapper.likeSavingsToLikeSavingsProductRes(likeSavings), HttpStatus.CREATED);
@@ -51,15 +53,16 @@ public class LikeSavingsController {
     /**
      * 관심 적금 삭제
      *
-     * @param memberId
+     * @param principal
      * @param interestId
      * @return ResponseEntity
      */
     @Operation(summary = "관심 적금 삭제")
     @DeleteMapping("/{like-saving-id}")
-    public ResponseEntity deleteLikeSavingProduct(@Positive @PathVariable("member-id") long memberId,
+    public ResponseEntity deleteLikeSavingProduct(Principal principal,
                                                   @Positive @PathVariable("like-saving-id") long interestId) {
 
+        long memberId = memberService.findMemberId(principal.getName());
         likeSavingsService.deleteLikeSavingProduct(memberId, interestId);
 
         return new ResponseEntity("성공적으로 삭제되었습니다.", HttpStatus.OK);
@@ -67,17 +70,19 @@ public class LikeSavingsController {
 
     /**
      * 회원 별 관심 적금 목록 조회
-     * @param memberId
+     *
+     * @param principal
      * @param page
      * @param size
      * @return
      */
     @Operation(summary = "회원 별 관심 적금 목록 조회")
     @GetMapping
-    public ResponseEntity findLikeSavingProducts(@Positive @PathVariable("member-id") long memberId,
+    public ResponseEntity findLikeSavingProducts(Principal principal,
                                                  @Positive @RequestParam(value = "page", required = false, defaultValue = "1") int page,
                                                  @Positive @RequestParam(value = "size", required = false, defaultValue = "10") int size) {
 
+        long memberId = memberService.findMemberId(principal.getName());
         Pageable pageable = PageRequest.of(page - 1, size);
         Page<LikeSavingProductsRes> pageLikeSavingProduct = likeSavingsService.getLikeSavingProducts(memberId, pageable);
         List<LikeSavingProductsRes> likeSavingProducts = pageLikeSavingProduct.getContent();


### PR DESCRIPTION
# 관심 적금 도메인
---
기존 memberId를 url에 노출했던 방식에서 token을 통해 memberId를 알아오는 방식으로 수정