### PR TITLE
[BE_MISC] 적금 필터링 조회 시 관심 적금 여부 확인 여부 추가

### DIFF
--- a/server/src/main/java/com/team1472/moas/installment_savings/controller/SavingProductsController.java
+++ b/server/src/main/java/com/team1472/moas/installment_savings/controller/SavingProductsController.java
@@ -3,6 +3,7 @@ package com.team1472.moas.installment_savings.controller;
 import com.team1472.moas.installment_savings.dto.SavingProductRes;
 import com.team1472.moas.installment_savings.dto.SavingsFilteringReq;
 import com.team1472.moas.installment_savings.service.SavingProductsService;
+import com.team1472.moas.member.service.MemberService;
 import com.team1472.moas.response.MultiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 import javax.validation.constraints.Positive;
+import java.security.Principal;
 import java.util.List;
 
 @RestController
@@ -26,18 +28,25 @@ import java.util.List;
 @Tag(name = "SavingProducts", description = "적금 API")
 public class SavingProductsController {
     private final SavingProductsService savingProductsService;
+    private final MemberService memberService;
 
     /**
      * 적금 정보 리스트 필터링 조회
      */
     @Operation(summary = "적금 정보 리스트 필터링 조회")
     @PostMapping
-    public ResponseEntity searchSavingProducts(@Positive @RequestParam(value = "page", required = false, defaultValue = "1") int page,
+    public ResponseEntity searchSavingProducts(Principal principal,
+                                               @Positive@RequestParam(value = "page", required = false, defaultValue = "1") int page,
                                                @Positive @RequestParam(value = "size", required = false, defaultValue = "10") int size,
                                                @Valid @RequestBody SavingsFilteringReq savingsFilteringReq) {
 
+        Long memberId = 0L;
+
         Pageable pageable = PageRequest.of(page - 1, size);
-        MultiResponse response = savingProductsService.findSavingsProducts(pageable, savingsFilteringReq);
+        if (principal != null) {
+            memberId = memberService.findMemberId(principal.getName());
+        }
+        MultiResponse response = savingProductsService.findSavingsProducts(pageable, savingsFilteringReq, memberId);
 
 
         return new ResponseEntity(response, HttpStatus.OK);

--- a/server/src/main/java/com/team1472/moas/installment_savings/dto/SavingProductRes.java
+++ b/server/src/main/java/com/team1472/moas/installment_savings/dto/SavingProductRes.java
@@ -39,12 +39,14 @@ public class SavingProductRes {
 
     private double intrRate2; //최고 우대 금리(소수점 2자리)
 
+    private Long likeSavingId; //관심 적금 id
+
     @Setter
     private long interestAmount; //세후 이자 금액 (세전 이자 금액 - 세금(15.4%))
 
     public SavingProductRes(String korCoNm, String finPrdtNm, String joinWay, String spclCnd, String joinDeny,
                             String joinMember, String etcNote, int maxLimit, String intrRateType, String intrRateTypeNm,
-                            String rsrvTypeNm, String saveTrm, String mtrtInt, double intrRate, double intrRate2) {
+                            String rsrvTypeNm, String saveTrm, String mtrtInt, double intrRate, double intrRate2, Long likeSavingId) {
 
         this.korCoNm = korCoNm;
         this.finPrdtNm = finPrdtNm;
@@ -61,5 +63,6 @@ public class SavingProductRes {
         this.mtrtInt = mtrtInt;
         this.intrRate = intrRate;
         this.intrRate2 = intrRate2;
+        this.likeSavingId = likeSavingId;
     }
 }

--- a/server/src/main/java/com/team1472/moas/installment_savings/dto/SavingProductRes.java
+++ b/server/src/main/java/com/team1472/moas/installment_savings/dto/SavingProductRes.java
@@ -9,10 +9,6 @@ import lombok.Setter;
 @NoArgsConstructor
 @AllArgsConstructor
 public class SavingProductRes {
-    private long savingsId; //적금 상품 id
-
-    private long interestId; //금리 id
-
     private String korCoNm; //금융회사 명
 
     private String finPrdtNm; //금융상품명
@@ -46,12 +42,10 @@ public class SavingProductRes {
     @Setter
     private long interestAmount; //세후 이자 금액 (세전 이자 금액 - 세금(15.4%))
 
-    public SavingProductRes(long savingsId, long interestId, String korCoNm, String finPrdtNm, String joinWay,
-                            String spclCnd, String joinDeny, String joinMember, String etcNote, int maxLimit,
-                            String intrRateType, String intrRateTypeNm, String rsrvTypeNm, String saveTrm,
-                            String mtrtInt, double intrRate, double intrRate2) {
-        this.savingsId = savingsId;
-        this.interestId = interestId;
+    public SavingProductRes(String korCoNm, String finPrdtNm, String joinWay, String spclCnd, String joinDeny,
+                            String joinMember, String etcNote, int maxLimit, String intrRateType, String intrRateTypeNm,
+                            String rsrvTypeNm, String saveTrm, String mtrtInt, double intrRate, double intrRate2) {
+
         this.korCoNm = korCoNm;
         this.finPrdtNm = finPrdtNm;
         this.joinWay = joinWay;

--- a/server/src/main/java/com/team1472/moas/installment_savings/repository/CustomSavingProductsRepository.java
+++ b/server/src/main/java/com/team1472/moas/installment_savings/repository/CustomSavingProductsRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface CustomSavingProductsRepository {
-    Page<SavingProductRes> findFilteringSavingProducts(Pageable pageable, SavingsFilteringReq savingsFilteringReq);
+    Page<SavingProductRes> findFilteringSavingProducts(Pageable pageable, SavingsFilteringReq savingsFilteringReq, Long memberId);
 }

--- a/server/src/main/java/com/team1472/moas/installment_savings/repository/CustomSavingProductsRepositoryImpl.java
+++ b/server/src/main/java/com/team1472/moas/installment_savings/repository/CustomSavingProductsRepositoryImpl.java
@@ -31,8 +31,6 @@ public class CustomSavingProductsRepositoryImpl implements CustomSavingProductsR
 
         List<SavingProductRes> savings = jpaQueryFactory.select(
                         Projections.constructor(SavingProductRes.class,
-                                installmentSavings.id,
-                                interestRate.id,
                                 installmentSavings.korCoNm,
                                 installmentSavings.finPrdtNm,
                                 installmentSavings.joinWay,

--- a/server/src/main/java/com/team1472/moas/installment_savings/service/SavingProductsService.java
+++ b/server/src/main/java/com/team1472/moas/installment_savings/service/SavingProductsService.java
@@ -16,8 +16,8 @@ import java.util.List;
 public class SavingProductsService {
     private final InterestRateRepository interestRateRepository;
 
-    public MultiResponse findSavingsProducts(Pageable pageable, SavingsFilteringReq filter) {
-         Page<SavingProductRes> pageSavingProduct = interestRateRepository.findFilteringSavingProducts(pageable, filter);
+    public MultiResponse findSavingsProducts(Pageable pageable, SavingsFilteringReq filter, Long memberId) {
+        Page<SavingProductRes> pageSavingProduct = interestRateRepository.findFilteringSavingProducts(pageable, filter, memberId);
 
         List<SavingProductRes> savingProducts = pageSavingProduct.getContent();
 

--- a/server/src/main/java/com/team1472/moas/installment_savings/service/SavingProductsService.java
+++ b/server/src/main/java/com/team1472/moas/installment_savings/service/SavingProductsService.java
@@ -8,11 +8,13 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class SavingProductsService {
     private final InterestRateRepository interestRateRepository;
 


### PR DESCRIPTION
# 적금 필터링 조회 기능

## token 추가 이유
관심 적금 기능이 생겨남에 따라 적금 필터링 조회 시에 자신이 등록한 관심 적금 여부도 확인 할 수 있게 하기 위해 해당 기능을 수정하였습니다.

## 구현 세부 사항
기존 interest_rate, installment_savings 테이블만 join 하고 있었는데 like_savings도 join에 추가하여 관심 적금 정보도 함께 조회해 올 수 있도록 하였습니다.
likeSavingId 필드가 null이 아닌 경우에는 해당 적금은 관심 등록이 되어 있는 것입니다.
boolean 값이 아닌 id 값을 사용한 이유는 관심 등록 삭제 기능이 likeSavingId 값을 통해 이루어지고 있기 때문에
조회 화면에서 관심 적금 등록 삭제도 가능하도록 하기 위해서 입니다.

## 변경 사항
- header
  - jwt 토큰을 넣으면 관심 등록 여부 확인 가능
  - jwt 토큰 넣지 않으면 likeSavingId값이 모두 null로 관심 등록 여부 확인 불가능

회원가입을 하지 않아도 적금 필터링 조회를 가능하도록 하기 위해 위와 같이 구현하였습니다.
 