### PR TITLE
[BE MISC] 목표 도메인 api 호출에 jwt token 적용

### DIFF
--- a/server/src/main/java/com/team1472/moas/goal/controller/GoalController.java
+++ b/server/src/main/java/com/team1472/moas/goal/controller/GoalController.java
@@ -3,9 +3,11 @@ package com.team1472.moas.goal.controller;
 
 import com.team1472.moas.goal.dto.GoalPatchReq;
 import com.team1472.moas.goal.dto.GoalPostReq;
+import com.team1472.moas.goal.dto.GoalRes;
 import com.team1472.moas.goal.entity.Goal;
 import com.team1472.moas.goal.mapper.GoalMapper;
 import com.team1472.moas.goal.service.GoalService;
+import com.team1472.moas.member.service.MemberService;
 import com.team1472.moas.response.MultiResponse;
 import com.team1472.moas.response.SingleResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -19,6 +21,7 @@ import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 import javax.validation.constraints.Positive;
+import java.security.Principal;
 import java.util.List;
 
 @RestController
@@ -29,13 +32,27 @@ import java.util.List;
 @Tag(name = "Goals", description = "목표 API")
 public class GoalController {
     private final GoalService goalService;
+    private final MemberService memberService;
     private final GoalMapper mapper;
 
-    //목표 등록
+    /**
+     * 목표 등록
+     *
+     * @param principal
+     * @param goalPostReq
+     * @return ResponseEntity
+     */
     @Operation(summary = "목표 등록")
-    @PostMapping("/{member-id}")
-    public ResponseEntity postGoal(@PathVariable("member-id") @Positive long memberId,
+    @PostMapping()
+    public ResponseEntity postGoal(Principal principal,
                                    @Valid @RequestBody GoalPostReq goalPostReq) {
+        long memberId;
+        try {
+            memberId = memberService.findMemberId(principal.getName());
+        } catch (NullPointerException e) {
+            return new ResponseEntity<>("회원정보 없음", HttpStatus.OK);
+        }
+
         Goal createdGoal = goalService.createGoal(mapper.goalPostReqToGoal(goalPostReq), memberId);
 
         return new ResponseEntity<>(
@@ -43,48 +60,97 @@ public class GoalController {
                 HttpStatus.CREATED);
     }
 
-    //목표 수정
+    /**
+     * 목표 수정
+     *
+     * @param principal
+     * @param goalId
+     * @return ResponseEntity
+     */
     @Operation(summary = "목표 수정")
-    @PatchMapping("/{member-id}/{goal-id}")
-    public ResponseEntity patchGoal(@PathVariable("member-id") @Positive long memberId,
+    @PatchMapping("/{goal-id}")
+    public ResponseEntity patchGoal(Principal principal,
                                     @PathVariable("goal-id") @Positive long goalId,
                                     @Valid @RequestBody GoalPatchReq goalPatchReq) {
-                                    
-        Goal goal = goalService.updateGoal(mapper.goalPatchReqToGoal(goalPatchReq),goalId);
+        long memberId;
+        try {
+            memberId = memberService.findMemberId(principal.getName());
+        } catch (NullPointerException e) {
+            return new ResponseEntity<>("회원정보 없음", HttpStatus.OK);
+        }
+
+        Goal goal = goalService.updateGoal(mapper.goalPatchReqToGoal(goalPatchReq),goalId, memberId);
 
         return new ResponseEntity<>(
                 new SingleResponse<>(mapper.goalToGoalRes(goal)),
                 HttpStatus.OK);
     }
 
-    //목표 상세 조회
+    /**
+     * 목표 상세 조회
+     *
+     * @param principal
+     * @param goalId
+     * @return ResponseEntity
+     */
     @Operation(summary = "목표 상세 조회")
-    @GetMapping("/{member-id}/{goal-id}")
-    public ResponseEntity getGoal(@PathVariable("member-id") @Positive long memberId,
+    @GetMapping("/{goal-id}")
+    public ResponseEntity getGoal(Principal principal,
                                   @PathVariable("goal-id") @Positive long goalId) {
-        Goal goal = goalService.findGoal(goalId);
+        long memberId;
+        try {
+            memberId = memberService.findMemberId(principal.getName());
+        } catch (NullPointerException e) {
+            return new ResponseEntity<>("회원정보 없음", HttpStatus.OK);
+        }
+
+        Goal goal = goalService.findGoal(goalId, memberId);
         return new ResponseEntity<>(
                 new SingleResponse<>(mapper.goalToGoalRes(goal)),
                 HttpStatus.OK);
     }
 
-    //목표 전체 조회(페이지네이션 적용 X)
+    /**
+     * 목표 전체 조회(페이지네이션 적용 X)
+     *
+     * @param principal
+     * @return ResponseEntity
+     */
     @Operation(summary = "목표 전체 조회")
-    @GetMapping("/{member-id}")
-    public ResponseEntity getQuestions(@PathVariable("member-id") @Positive long memberId) {
-        List<Goal> goals = goalService.findGoals();
+    @GetMapping()
+    public ResponseEntity getQuestions(Principal principal) {
+        long memberId;
+        try {
+            memberId = memberService.findMemberId(principal.getName());
+        } catch (NullPointerException e) {
+            return new ResponseEntity<>("회원정보 없음", HttpStatus.OK);
+        }
+
+        List<GoalRes> goals = goalService.findGoals(memberId);
         return new ResponseEntity<>(
-                new MultiResponse<>(mapper.goalsToGoalRes(goals)),
+                new MultiResponse<>(goals),
                 HttpStatus.OK);
     }
 
-    //목표 삭제
+    /**
+     * 목표 삭제
+     *
+     * @param principal
+     * @param goalId
+     * @return ResponseEntity
+     */
     @Operation(summary = "목표 삭제")
-    @DeleteMapping("/{member-id}/{goal-id}")
-    public ResponseEntity deleteGoal(@PathVariable("member-id") @Positive long memberId,
+    @DeleteMapping("/{goal-id}")
+    public ResponseEntity deleteGoal(Principal principal,
                                      @PathVariable("goal-id") @Positive long goalId) {
-                                     
-        goalService.deleteGoal(goalId);
-        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+        long memberId;
+        try {
+            memberId = memberService.findMemberId(principal.getName());
+        } catch (NullPointerException e) {
+            return new ResponseEntity<>("회원정보 없음", HttpStatus.OK);
+        }
+
+        goalService.deleteGoal(goalId, memberId);
+        return new ResponseEntity<>("성공적으로 삭제되었습니다.",HttpStatus.OK);
     }
 }

--- a/server/src/main/java/com/team1472/moas/goal/repository/GoalRepository.java
+++ b/server/src/main/java/com/team1472/moas/goal/repository/GoalRepository.java
@@ -1,10 +1,13 @@
 package com.team1472.moas.goal.repository;
 
+import com.team1472.moas.goal.dto.GoalRes;
 import com.team1472.moas.goal.entity.Goal;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface GoalRepository extends JpaRepository<Goal, Long> {
+    Optional<Goal> findByIdAndMemberId(long Id, long memberId);
+    List<GoalRes> findGoalsByMemberId(long memberId);
 }

--- a/server/src/main/java/com/team1472/moas/goal/service/GoalService.java
+++ b/server/src/main/java/com/team1472/moas/goal/service/GoalService.java
@@ -2,6 +2,7 @@ package com.team1472.moas.goal.service;
 
 import com.team1472.moas.exception.BusinessLogicException;
 import com.team1472.moas.exception.ExceptionCode;
+import com.team1472.moas.goal.dto.GoalRes;
 import com.team1472.moas.goal.entity.Goal;
 import com.team1472.moas.goal.repository.GoalRepository;
 import com.team1472.moas.member.entity.Member;
@@ -26,17 +27,22 @@ public class GoalService{
 
     //목표 생성
     public Goal createGoal(Goal goal, long memberId) {
+        //회원 정보 추가
         Member member = memberService.findMember(memberId);
         goal.addMember(member);
 
-        savePeriod(goal); //납입 기간 계산
+        //이미지 url 정보 존재 시 저장
+        Optional.ofNullable(goal.getUrl()).ifPresent(url -> goal.setUrl(url));
+
+        //납입 기간 자동 계산하여 저장
+        savePeriod(goal);
 
         return goalRepository.save(goal);
     }
 
     //목표 수정
-    public Goal updateGoal(Goal goal, long goalId) {
-        Goal findGoal = findVerifiedGoal(goalId);
+    public Goal updateGoal(Goal goal, long goalId, long memberId) {
+        Goal findGoal = findVerifiedGoalByMemberId(goalId, memberId);
 
         Optional.ofNullable(goal.getGoalName()).ifPresent(goalName -> findGoal.setGoalName(goalName));
         Optional.ofNullable(goal.getPrice()).ifPresent(price -> findGoal.setPrice(price));
@@ -51,16 +57,16 @@ public class GoalService{
     }
 
     //목표 상세 조회
-    public Goal findGoal(long goalId) {
+    public Goal findGoal(long goalId, long memberId) {
         saveProgress(goalId);
         saveStatus(goalId);
-        return findVerifiedGoal(goalId);
+        return findVerifiedGoalByMemberId(goalId, memberId);
     }
 
     //목표 전체 조회 (List)
-    public List<Goal> findGoals() {
-        List<Goal> goals = goalRepository.findAll();
-        for (Goal goal : goals) {
+    public List<GoalRes> findGoals(long memberId) {
+        List<GoalRes> goals = goalRepository.findGoalsByMemberId(memberId);
+        for (GoalRes goal : goals) {
             saveProgress(goal.getId());
             saveStatus(goal.getId());
         }
@@ -68,17 +74,21 @@ public class GoalService{
     }
 
     //목표 삭제
-    public void deleteGoal(long goalId) {
-        Goal findGoal = findVerifiedGoal(goalId);
+    public void deleteGoal(long goalId, long memberId) {
+        Goal findGoal = findVerifiedGoalByMemberId(goalId, memberId);
         goalRepository.delete(findGoal);
     }
 
-    //id로 특정 목표가 존재하는지 찾아서 리턴
-    //존재하지 않을 시 에러 메세지 띄움
+    //goalId와 memberId로 특정 목표 찾기
+    private Goal findVerifiedGoalByMemberId(long goalId, long memberId) {
+        return goalRepository.findByIdAndMemberId(goalId, memberId)
+                .orElseThrow(() -> new BusinessLogicException(ExceptionCode.GOAL_NOT_FOUND));
+    }
+
+    //goalId로 특정 목표 찾기
     private Goal findVerifiedGoal(long goalId) {
-        Optional<Goal> optionalGoal = goalRepository.findById(goalId);
-        Goal findGoal = optionalGoal.orElseThrow(() -> new BusinessLogicException(ExceptionCode.GOAL_NOT_FOUND));
-        return findGoal;
+        return goalRepository.findById(goalId)
+                .orElseThrow(() -> new BusinessLogicException(ExceptionCode.GOAL_NOT_FOUND));
     }
 
     //납입기간 설정


### PR DESCRIPTION
## 변경 내용
- 목표 등록 메서드
- 목표 수정 메서드
- 목표 상세 조회 메서드
- 목표 전체 조회 메서드
- 목표 삭제 메서드

## 변경 사유
기존에는 memberId 를 @PathVariable로 받아서 uri에 memberId가 노출되는 문제점이 있었습니다.

jwt token을 활용하여 인증된 회원의 정보를 uri에 노출하지 않고, 목표 도메인의 메서드를 활용할 수 있게 수정했습니다.