### PR TITLE
[BE Fix] Goal Entity에서 해당 내부값으로 계산하는 메서드 추가

### DIFF
--- a/server/src/main/java/com/team1472/moas/goal/entity/Goal.java
+++ b/server/src/main/java/com/team1472/moas/goal/entity/Goal.java
@@ -7,6 +7,8 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import javax.persistence.*;
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
 
 @NoArgsConstructor
 @Getter
@@ -59,6 +61,55 @@ public class Goal extends Auditable {
 
         GoalStatus(String status) {
             this.status = status;
+        }
+    }
+
+    //납입기간 설정 = (목표금액)/월 납입금
+    //목표 등록하는 순간에 한 달치 입금되었다고 가정
+    public void savePeriod() {
+        //월 납입금이 목표 금액보다 크거나 같을 때 -> 0개월 걸림
+        if (this.getMonthlyPayment() >= this.getPrice()) {
+            this.setPeriod(0);
+        }
+        //목표 금액이 월 납입금보다 클 때
+        else {
+            int period = (int) Math.ceil((double) this.getPrice() / this.getMonthlyPayment());
+            if (period - 1 > 0) {
+                this.setPeriod(period - 1);
+            }
+        }
+    }
+
+    //status 설정
+    public void saveStatus() {
+        if (this.getProgress() == 100) {
+            this.setStatus(Goal.GoalStatus.COMPLETED);
+        } else {
+            this.setStatus(Goal.GoalStatus.PROGRESS);
+        }
+    }
+
+    //진척도(%) 설정
+    //목표 등록하는 순간에 한 달치 입금되었다고 가정
+    public void saveProgress() {
+        LocalDate createdDate;
+        if (this.getCreatedAt() == null) {
+            createdDate = LocalDate.now();
+        } else {
+            createdDate = this.getCreatedAt().toLocalDate(); //목표 생성 시간
+        }
+        LocalDate localDate = LocalDate.now(); //현재 시간
+
+        double month = (double) ChronoUnit.MONTHS.between(createdDate, localDate); //경과한 시간 (단위: 월)
+        int goalPeriod = this.getPeriod() + 1; //설정된 납부 기간 + 1
+
+        //만약 0개월 걸릴 때
+        if (goalPeriod == 1) {
+            this.setProgress(100);
+        } else {
+            double progress = (month + 1) / goalPeriod * 100;
+            int result = (int) Math.round(progress);
+            this.setProgress(result);
         }
     }
 }


### PR DESCRIPTION
## 주요 변경 내용
1. 목표 생성 시점부터 한 달 납입금이 입금 되었다고 가정하고 계산식 변경
2. 기존에 Service 단에서 작동하던 메서드 객체 내부값으로 계산하는 메서드로 위치 이동
    - savePeriod()
    - saveProgress()
    - saveStatus()

## 변경사유
1. 기존에 POST 시, 계산 메서드를 실행만 하고 값을 DB에 저장하지 않는 문제점이 있었음
2. 내부 값끼리의 연산이므로, 객체 안에 메서드 생성하여 객체 지향 충족